### PR TITLE
Bug fix:

### DIFF
--- a/4ti2Interface/gap/4ti2Interface.gi
+++ b/4ti2Interface/gap/4ti2Interface.gi
@@ -557,11 +557,11 @@ InstallGlobalFunction( 4ti2Interface_zsolve_equalities_and_inequalities_in_posit
     
     if Length( eqs ) > 0 then
         
-        signs := ListWithIdenticalEntries( Length( eqs[ 1 ] ), 0 );
+        signs := ListWithIdenticalEntries( Length( eqs[ 1 ] ), 1 );
         
     else
         
-        signs := ListWithIdenticalEntries( Length( ineqs[ 1 ] ), 0 );
+        signs := ListWithIdenticalEntries( Length( ineqs[ 1 ] ), 1 );
         
     fi;
     


### PR DESCRIPTION
According to the 4ti2Interface manual, 1 means that x_i >=0 whilst 0 means that x_i can have arbitrary sign. Thus for a computation in the positive orthant we need all signs to be 1 (rather than 0).