### PR TITLE
Remove references to Netscape and .zoo from READMEs

### DIFF
--- a/4ti2Interface/README
+++ b/4ti2Interface/README
@@ -6,19 +6,12 @@ to provide it to other methods.
 To get the newest version of this GAP 4 package download one of the
 archive files
     4ti2Interface-x.x.tar.gz
-    4ti2Interface-x.x.zoo
     4ti2Interface-x.x.tar.bz2
     4ti2Interface-x.x.zip
 and unpack it using 
-    gunzip 4ti2Interface-x.x.tar.gz; tar xvf 4ti2Interface-x.x.tar
+    tar xvf 4ti2Interface-x.x.tar.gz
 respectively
-    unzoo -x 4ti2Interface-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip 4ti2Interface-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `4ti2Interface'.

--- a/ExamplesForHomalg/README
+++ b/ExamplesForHomalg/README
@@ -3,19 +3,13 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     ExamplesForHomalg-x.x.tar.gz
-    ExamplesForHomalg-x.x.zoo
     ExamplesForHomalg-x.x.tar.bz2
     ExamplesForHomalg-x.x.zip
 and unpack it using 
-    gunzip ExamplesForHomalg-x.x.tar.gz; tar xvf ExamplesForHomalg-x.x.tar
+    tar xvf ExamplesForHomalg-x.x.tar.gz
 respectively
-    unzoo -x ExamplesForHomalg-x.x.zoo
+    unzip ExamplesForHomalg-x.x.zip
 and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `ExamplesForHomalg'.

--- a/Gauss/README
+++ b/Gauss/README
@@ -4,12 +4,7 @@ To get the newest version of this GAP 4 package download the archive
 file
     Gauss.tar.gz
 and unpack it using 
-    gunzip Gauss.tar.gz; tar xvf Gauss.tar
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    tar xvf Gauss.tar.gz
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `Gauss'.

--- a/GaussForHomalg/README
+++ b/GaussForHomalg/README
@@ -4,12 +4,7 @@ To get the newest version of this GAP 4 package download the archive
 file
     GaussForHomalg.tar.gz
 and unpack it using 
-    gunzip GaussForHomalg.tar.gz; tar xvf GaussForHomalg.tar
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    tar xvf GaussForHomalg.tar.gz
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `GaussForHomalg'.

--- a/GradedModules/README
+++ b/GradedModules/README
@@ -3,19 +3,13 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     GradedModules-x.x.tar.gz
-    GradedModules-x.x.zoo
     GradedModules-x.x.tar.bz2
     GradedModules-x.x.zip
 and unpack it using 
-    gunzip GradedModules-x.x.tar.gz; tar xvf GradedModules-x.x.tar
+    tar xvf GradedModules-x.x.tar.gz
 respectively
-    unzoo -x GradedModules-x.x.zoo
+    unzip GradedModules-x.x.zip
 and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `GradedModules'.

--- a/GradedRingForHomalg/README
+++ b/GradedRingForHomalg/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     GradedRingForHomalg-x.x.tar.gz
-    GradedRingForHomalg-x.x.zoo
     GradedRingForHomalg-x.x.tar.bz2
     GradedRingForHomalg-x.x.zip
 and unpack it using 
-    gunzip GradedRingForHomalg-x.x.tar.gz; tar xvf GradedRingForHomalg-x.x.tar
+    tar xvf GradedRingForHomalg-x.x.tar.gz
 respectively
-    unzoo -x GradedRingForHomalg-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip GradedRingForHomalg-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `GradedRingForHomalg'.

--- a/HomalgToCAS/README
+++ b/HomalgToCAS/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     HomalgToCAS-x.x.tar.gz
-    HomalgToCAS-x.x.zoo
     HomalgToCAS-x.x.tar.bz2
     HomalgToCAS-x.x.zip
 and unpack it using 
-    gunzip HomalgToCAS-x.x.tar.gz; tar xvf HomalgToCAS-x.x.tar
+    tar xvf HomalgToCAS-x.x.tar.gz
 respectively
-    unzoo -x HomalgToCAS-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip HomalgToCAS-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `HomalgToCAS'.

--- a/IO_ForHomalg/README
+++ b/IO_ForHomalg/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     IO_ForHomalg-x.x.tar.gz
-    IO_ForHomalg-x.x.zoo
     IO_ForHomalg-x.x.tar.bz2
     IO_ForHomalg-x.x.zip
 and unpack it using 
-    gunzip IO_ForHomalg-x.x.tar.gz; tar xvf IO_ForHomalg-x.x.tar
+    tar xvf IO_ForHomalg-x.x.tar.gz
 respectively
-    unzoo -x IO_ForHomalg-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip IO_ForHomalg-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `IO_ForHomalg'.

--- a/LocalizeRingForHomalg/README
+++ b/LocalizeRingForHomalg/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     LocalizeRingForHomalg-x.x.tar.gz
-    LocalizeRingForHomalg-x.x.zoo
     LocalizeRingForHomalg-x.x.tar.bz2
     LocalizeRingForHomalg-x.x.zip
 and unpack it using 
-    gunzip LocalizeRingForHomalg-x.x.tar.gz; tar xvf LocalizeRingForHomalg-x.x.tar
+    tar xvf LocalizeRingForHomalg-x.x.tar.gz
 respectively
-    unzoo -x LocalizeRingForHomalg-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip LocalizeRingForHomalg-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `LocalizeRingForHomalg'.

--- a/MatricesForHomalg/README
+++ b/MatricesForHomalg/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     MatricesForHomalg-x.x.tar.gz
-    MatricesForHomalg-x.x.zoo
     MatricesForHomalg-x.x.tar.bz2
     MatricesForHomalg-x.x.zip
 and unpack it using 
-    gunzip MatricesForHomalg-x.x.tar.gz; tar xvf MatricesForHomalg-x.x.tar
+    tar xvf MatricesForHomalg-x.x.tar.gz
 respectively
-    unzoo -x MatricesForHomalg-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip MatricesForHomalg-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `MatricesForHomalg'.

--- a/Modules/README
+++ b/Modules/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     Modules-x.x.tar.gz
-    Modules-x.x.zoo
     Modules-x.x.tar.bz2
     Modules-x.x.zip
 and unpack it using 
-    gunzip Modules-x.x.tar.gz; tar xvf Modules-x.x.tar
+    tar xvf Modules-x.x.tar.gz
 respectively
-    unzoo -x Modules-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip Modules-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `Modules'.

--- a/PolymakeInterface/README
+++ b/PolymakeInterface/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     PolymakeInterface-x.x.tar.gz
-    PolymakeInterface-x.x.zoo
     PolymakeInterface-x.x.tar.bz2
     PolymakeInterface-x.x.zip
 and unpack it using 
-    gunzip PolymakeInterface-x.x.tar.gz; tar xvf PolymakeInterface-x.x.tar
+    tar xvf PolymakeInterface-x.x.tar.gz
 respectively
-    unzoo -x PolymakeInterface-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip PolymakeInterface-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `PolymakeInterface'.

--- a/RingsForHomalg/README
+++ b/RingsForHomalg/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     RingsForHomalg-x.x.tar.gz
-    RingsForHomalg-x.x.zoo
     RingsForHomalg-x.x.tar.bz2
     RingsForHomalg-x.x.zip
 and unpack it using 
-    gunzip RingsForHomalg-x.x.tar.gz; tar xvf RingsForHomalg-x.x.tar
+    tar xvf RingsForHomalg-x.x.tar.gz
 respectively
-    unzoo -x RingsForHomalg-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip RingsForHomalg-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `RingsForHomalg'.

--- a/SCO/README
+++ b/SCO/README
@@ -4,12 +4,7 @@ To get the newest version of this GAP 4 package download the archive
 file
     SCO.tar.gz
 and unpack it using 
-    gunzip SCO.tar.gz; tar xvf SCO.tar
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    tar xvf SCO.tar.gz
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `SCO'.

--- a/ToolsForHomalg/README
+++ b/ToolsForHomalg/README
@@ -8,19 +8,12 @@ and ToDoLists, which are a way to spread knowledge between objects.
 To get the newest version of this GAP 4 package download one of the
 archive files
     ToolsForHomalg-x.x.tar.gz
-    ToolsForHomalg-x.x.zoo
     ToolsForHomalg-x.x.tar.bz2
     ToolsForHomalg-x.x.zip
 and unpack it using 
-    gunzip ToolsForHomalg-x.x.tar.gz; tar xvf ToolsForHomalg-x.x.tar
+    tar xvf ToolsForHomalg-x.x.tar.gz
 respectively
-    unzoo -x ToolsForHomalg-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip ToolsForHomalg-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `ToolsForHomalg'.

--- a/ToricVarieties/README
+++ b/ToricVarieties/README
@@ -3,19 +3,12 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     ToricVarieties-x.x.tar.gz
-    ToricVarieties-x.x.zoo
     ToricVarieties-x.x.tar.bz2
     ToricVarieties-x.x.zip
 and unpack it using 
-    gunzip ToricVarieties-x.x.tar.gz; tar xvf ToricVarieties-x.x.tar
+    tar xvf ToricVarieties-x.x.tar.gz
 respectively
-    unzoo -x ToricVarieties-x.x.zoo
-and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
+    unzip ToricVarieties-x.x.zip
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `ToricVarieties'.

--- a/homalg/README
+++ b/homalg/README
@@ -3,19 +3,13 @@
 To get the newest version of this GAP 4 package download one of the
 archive files
     homalg-x.x.tar.gz
-    homalg-x.x.zoo
     homalg-x.x.tar.bz2
     homalg-x.x.zip
 and unpack it using 
-    gunzip homalg-x.x.tar.gz; tar xvf homalg-x.x.tar
+    tar xvf homalg-x.x.tar.gz
 respectively
-    unzoo -x homalg-x.x.zoo
+    unzip homalg-x.x.zip
 and so on.
-
-(Note that if you use a browser like `netscape' for downloading the
-archive file the `gunzip' step above may already be done by the browser,
-although the name of your file may still have the misleading `.gz'
-extension.)
 
 Do this preferably (but not necessarily) inside the `pkg' subdirectory
 of your GAP 4 installation. It creates a subdirectory called `homalg'.


### PR DESCRIPTION
The same should be done for your non-deposited packages, but I figured you could do that yourself, without me having to open a dozen pull requests... :)