### PR TITLE
Reversed logic for ToDoList activation:

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -9,7 +9,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2017.09.10", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2018.01.25", ## Sebas' version
+  "2018.01.30", ## Sebas' version
 ## this line prevents merge conflicts
 ] ),
 

--- a/ToolsForHomalg/gap/ToDoListEntry.gi
+++ b/ToolsForHomalg/gap/ToDoListEntry.gi
@@ -381,7 +381,9 @@ InstallMethod( AddToToDoList,
         
     od;
     
-    if not ForAny( source_object_list, CanHaveAToDoList ) then
+    if not TODO_LISTS.activated
+       or ForAny( source_object_list, CannotHaveAToDoList )
+       or ForAny( source_object_list, i -> not IsAttributeStoringRep( i ) ) then
         
         return;
         
@@ -397,7 +399,7 @@ InstallMethod( AddToToDoList,
             
             Add( todo_list!.already_done, entry );
             
-        elif result = false and not PreconditionsDefinitelyNotFulfilled( entry ) and CanHaveAToDoList( source[ 1 ] ) then
+        elif result = false and not PreconditionsDefinitelyNotFulfilled( entry ) and ( TODO_LISTS.activated or CanHaveAToDoList( source[ 1 ] ) ) then
             
             TODOLIST_ADD_TO_RECORD_AT_POSITION( todo_list!.todos, source[ 2 ], entry );
             

--- a/ToolsForHomalg/gap/ToDoLists.gd
+++ b/ToolsForHomalg/gap/ToDoLists.gd
@@ -103,6 +103,10 @@ DeclareGlobalFunction( "ToolsForHomalg_ToDoList_TaceProof_RecursivePart" );
 
 DeclareGlobalVariable( "TODO_LISTS" );
 
+
+## These two filters are mutually exclusive,
+## but not every object needs to have one set.
+DeclareFilter( "CannotHaveAToDoList", IsObject );
 DeclareFilter( "CanHaveAToDoList", IsObject );
 
 DeclareProperty( "MaintenanceMethodForToDoLists", IsObject );

--- a/ToolsForHomalg/gap/ToDoLists.gi
+++ b/ToolsForHomalg/gap/ToDoLists.gi
@@ -438,7 +438,7 @@ end );
 ORIG_RunImmediateMethods := RunImmediateMethods;
 MakeReadWriteGlobal("RunImmediateMethods");
 NEW_RunImmediateMethods := function( obj, bitlist )
-                              if HasSomethingToDo( obj ) and CanHaveAToDoList( obj ) and TODO_LISTS.activated then
+                              if HasSomethingToDo( obj ) and not CannotHaveAToDoList( obj ) and ( TODO_LISTS.activated or CanHaveAToDoList( obj ) ) then
                                   ProcessToDoList_Real( obj, bitlist );
                               fi;
                               ORIG_RunImmediateMethods( obj, bitlist );
@@ -454,30 +454,16 @@ MakeReadOnlyGlobal("RunImmediateMethods");
 ###########################################
 
 ##
-InstallImmediateMethod( MaintenanceMethodForToDoLists,
-                        IsAttributeStoringRep,
-                        0,
-                        
-  function( obj )
-    
-    if TODO_LISTS.activated then
-        
-        SetFilterObj( obj, CanHaveAToDoList );
-        
-    fi;
-    
-    TryNextMethod();
-    
-end );
-
-##
 InstallMethod( ActivateToDoList,
                "for one object",
                [ IsObject ],
                
   function( obj )
     
-    SetFilterObj( obj, CanHaveAToDoList );
+    if not TODO_LISTS.activated then
+        SetFilterObj( obj, CanHaveAToDoList );
+    fi;
+    ResetFilterObj( obj, CannotHaveAToDoList );
     
 end );
 
@@ -500,6 +486,9 @@ InstallMethod( DeactivateToDoList,
   function( obj )
     
     ResetFilterObj( obj, CanHaveAToDoList );
+    if TODO_LISTS.activated then
+        SetFilterObj( obj, CannotHaveAToDoList );
+    fi;
     
 end );
 


### PR DESCRIPTION
Instead of marking objects that can have a todo list,
mark objects that cannot have a todo list.