### PR TITLE
EvalUnionOfColumns with list of matrices of arbitrary length

### DIFF
--- a/Gauss/doc/Gauss.xml
+++ b/Gauss/doc/Gauss.xml
@@ -477,7 +477,7 @@ in source code should just check out the files in the
      <#Include Label="CertainRows">
      <#Include Label="CertainColumns">
      <#Include Label="UnionOfRowsOp">
-     <#Include Label="UnionOfColumnsOp">
+     <#Include Label="UnionOfColumns">
      <#Include Label="SparseDiagMat">
      <#Include Label="Nrows">
      <#Include Label="Ncols">

--- a/Gauss/gap/GaussDense.gd
+++ b/Gauss/gap/GaussDense.gd
@@ -46,8 +46,3 @@ if not IsBound( UnionOfRows ) then
     DeclareGlobalFunction( "UnionOfRows" );
     BindGlobal( "__INSTALL_UNIONOFROWS_IN_GAUSS", true );
 fi;
-
-if not IsBound( UnionOfColumns ) then
-    DeclareGlobalFunction( "UnionOfColumns" );
-    BindGlobal( "__INSTALL_UNIONOFCOLS_IN_GAUSS", true );
-fi;

--- a/Gauss/gap/GaussDense.gi
+++ b/Gauss/gap/GaussDense.gi
@@ -506,27 +506,3 @@ if IsBound( __INSTALL_UNIONOFROWS_IN_GAUSS ) and __INSTALL_UNIONOFROWS_IN_GAUSS 
     MakeReadWriteGlobal( "__INSTALL_UNIONOFROWS_IN_GAUSS" );
     UnbindGlobal( "__INSTALL_UNIONOFROWS_IN_GAUSS" );
 fi;
-
-##
-if IsBound( __INSTALL_UNIONOFCOLS_IN_GAUSS ) and __INSTALL_UNIONOFCOLS_IN_GAUSS then
-    InstallGlobalFunction( UnionOfColumns,
-    function( arg )
-        local nargs;
-        
-        nargs := Length( arg );
-        
-        if nargs = 0  then
-            Error( "<arg> must be nonempty" );
-        elif Length( arg ) = 1 and IsList( arg[1] )  then
-            if IsEmpty( arg[1] )  then
-                Error( "<arg>[1] must be nonempty" );
-            fi;
-            arg := arg[1];
-        fi;
-        
-        return UnionOfColumnsOp( arg, arg[1] );
-        
-    end );
-    MakeReadWriteGlobal( "__INSTALL_UNIONOFCOLS_IN_GAUSS" );
-    UnbindGlobal( "__INSTALL_UNIONOFCOLS_IN_GAUSS" );
-fi;

--- a/GradedModules/gap/GradedModuleMap.gi
+++ b/GradedModules/gap/GradedModuleMap.gi
@@ -186,7 +186,7 @@ InstallMethod( NormalizeGradedMorphism,
     T1 := HomalgVoidMatrix( K );
     T2 := SyzygiesOfColumns( m );
     m := BasisOfColumnsCoeff( m, T1 );
-    Tr := UnionOfColumnsOp( T1, T2 );
+    Tr := UnionOfColumns( T1, T2 );
     
     rank := NrRows( m );
     
@@ -216,20 +216,20 @@ InstallMethod( NormalizeGradedMorphism,
     
     if left then
         Assert( 7, S * MatrixOfMap( phi ) = UnionOfRowsOp( 
-                UnionOfColumnsOp( HomalgIdentityMatrix( rank, S ), HomalgZeroMatrix( rank, NrGenerators( N ) - rank, S ) ),
-                UnionOfColumnsOp( HomalgZeroMatrix( NrGenerators( M ) - rank, rank, S ), HomalgZeroMatrix( NrGenerators( M ) - rank, NrGenerators( N ) - rank, S ) ) 
+                UnionOfColumns( HomalgIdentityMatrix( rank, S ), HomalgZeroMatrix( rank, NrGenerators( N ) - rank, S ) ),
+                UnionOfColumns( HomalgZeroMatrix( NrGenerators( M ) - rank, rank, S ), HomalgZeroMatrix( NrGenerators( M ) - rank, NrGenerators( N ) - rank, S ) ) 
             ) );
     else
         Assert( 7, S * MatrixOfMap( phi ) = UnionOfRowsOp( 
-                UnionOfColumnsOp( HomalgIdentityMatrix( rank, S ), HomalgZeroMatrix( rank, NrGenerators( M ) - rank, S ) ),
-                UnionOfColumnsOp( HomalgZeroMatrix( NrGenerators( N ) - rank, rank, S ), HomalgZeroMatrix( NrGenerators( N ) - rank, NrGenerators( M ) - rank, S ) )
+                UnionOfColumns( HomalgIdentityMatrix( rank, S ), HomalgZeroMatrix( rank, NrGenerators( M ) - rank, S ) ),
+                UnionOfColumns( HomalgZeroMatrix( NrGenerators( N ) - rank, rank, S ), HomalgZeroMatrix( NrGenerators( N ) - rank, NrGenerators( M ) - rank, S ) )
             ) );
     fi;
         
     k := NrGenerators( N ) - rank;
     
     if left then
-        complement := UnionOfColumnsOp( HomalgZeroMatrix( k, rank, S ), HomalgIdentityMatrix( k, S ) );
+        complement := UnionOfColumns( HomalgZeroMatrix( k, rank, S ), HomalgIdentityMatrix( k, S ) );
     else
         complement := UnionOfRowsOp( HomalgZeroMatrix( rank, k, S ), HomalgIdentityMatrix( k, S ) );
     fi;

--- a/GradedModules/gap/OtherFunctors.gi
+++ b/GradedModules/gap/OtherFunctors.gi
@@ -556,7 +556,7 @@ InstallMethod( SplitLinearMapAccordingToIndeterminates,
           extension_matrix := HomalgZeroMatrix( NrGenerators( Range( phi ) ), 0, K );
           for k in [ 1 .. l_var ] do
               c := CertainRows( matrix_of_extension, [ (k-1) * t + 1 .. k * t ] );
-              extension_matrix := UnionOfColumnsOp( extension_matrix, c );
+              extension_matrix := UnionOfColumns( extension_matrix, c );
           od;
       fi;
       

--- a/GradedRingForHomalg/gap/GradedRingTools.gi
+++ b/GradedRingForHomalg/gap/GradedRingTools.gi
@@ -108,7 +108,7 @@ InstallValue( CommonHomalgTableForGradedRingsTools,
         
         UnionOfColumns :=
           function( A, B )
-            return UnionOfColumnsOp( UnderlyingMatrixOverNonGradedRing( A ), UnderlyingMatrixOverNonGradedRing( B ) );
+            return UnionOfColumns( UnderlyingMatrixOverNonGradedRing( A ), UnderlyingMatrixOverNonGradedRing( B ) );
           end,
         
         DiagMat :=

--- a/GradedRingForHomalg/gap/SingularTools.gi
+++ b/GradedRingForHomalg/gap/SingularTools.gi
@@ -287,7 +287,7 @@ InstallValue( GradedRingTableForSingularTools,
                NonTrivialDegreePerRowWithColPosition :=
                  function( M )
                    local L;
-                   
+
                    L := homalgSendBlocking( [ "NonTrivialDegreePerRowWithColPosition( ", M, " )" ], "need_output", HOMALG_IO.Pictograms.NonTrivialDegreePerRow );
                    
                    L := StringToIntList( L );

--- a/LocalizeRingForHomalg/gap/LocalizeRingAtPrimeTools.gi
+++ b/LocalizeRingForHomalg/gap/LocalizeRingAtPrimeTools.gi
@@ -156,7 +156,7 @@ InstallValue( CommonHomalgTableForLocalizedRingsAtPrimeIdealsTools,
                UnionOfColumns :=
                  function( A, B )
                    
-                   return UnionOfColumnsOp( Eval( A ), Eval( B ) );
+                   return UnionOfColumns( Eval( A ), Eval( B ) );
                  end,
                
                DiagMat :=

--- a/LocalizeRingForHomalg/gap/LocalizeRingBasic.gi
+++ b/LocalizeRingForHomalg/gap/LocalizeRingBasic.gi
@@ -271,7 +271,7 @@ RelativeSyzygiesGeneratorsOfColumns :=
     
     Info( InfoLocalizeRingForHomalg, 2, "Start RelativeSyzygiesGeneratorsOfColumns with ", NrRows( M ), "x", NrColumns( M ), " and ", NrRows( N ), "x", NrColumns( N ) );
     
-    CommonDenomMatrix := UnionOfColumnsOp( M, N );
+    CommonDenomMatrix := UnionOfColumns( M, N );
     M2 := CertainColumns( CommonDenomMatrix, [ 1 .. NrColumns( M ) ] );
     N2 := CertainColumns( CommonDenomMatrix, [ NrColumns( M ) + 1 .. NrColumns( CommonDenomMatrix ) ] );
     
@@ -380,7 +380,7 @@ DecideZeroColumns :=
         B2 := HomalgLocalMatrix( DecideZeroColumns( B1, A1 ), R );
         
         if not IsZero( B2 ) then
-          A2 := UnionOfColumnsOp( A1, B1 * gens );
+          A2 := UnionOfColumns( A1, B1 * gens );
           A2 := BasisOfColumns( A2 );
           B3 := HomalgLocalMatrix( DecideZeroColumns( B1, A2 ), R );
           if IsZero( B3 ) then
@@ -388,7 +388,7 @@ DecideZeroColumns :=
           fi;
         fi;
         
-        N := UnionOfColumnsOp( N, B2 );
+        N := UnionOfColumns( N, B2 );
         
     od;
     
@@ -510,7 +510,7 @@ DecideZeroColumnsEffectively :=
         B2 := HomalgLocalMatrix( DecideZeroColumnsEffectively( B1, A1, S1 ), R );
         
         if not IsZero( B2 ) then
-          A2 := UnionOfColumnsOp( A1, B1 * gens );
+          A2 := UnionOfColumns( A1, B1 * gens );
           SS := HomalgVoidMatrix( GlobalR );
           A2 := BasisOfColumnsCoeff( A2, SS );
           S := HomalgVoidMatrix( GlobalR );
@@ -535,8 +535,8 @@ DecideZeroColumnsEffectively :=
         
         fi;
         
-        TT := UnionOfColumnsOp( TT, S );
-        N := UnionOfColumnsOp( N, B2 );
+        TT := UnionOfColumns( TT, S );
+        N := UnionOfColumns( N, B2 );
         
         Assert( 7, HomalgLocalMatrix( A1, R ) * S + HomalgLocalMatrix( B1, R ) = B2 );
         

--- a/LocalizeRingForHomalg/gap/LocalizeRingTools.gi
+++ b/LocalizeRingForHomalg/gap/LocalizeRingTools.gi
@@ -198,7 +198,7 @@ InstallValue( CommonHomalgTableForLocalizedRingsTools,
                    c := Cancel( a[2], b[2] );
                    
                    return [
-                     UnionOfColumnsOp( c[2] * a[1], c[1] * b[1] ),
+                     UnionOfColumns( c[2] * a[1], c[1] * b[1] ),
                      c[1] * b[2]
                    ];
                  end,

--- a/MatricesForHomalg/examples/COLEM-LIMAT.g
+++ b/MatricesForHomalg/examples/COLEM-LIMAT.g
@@ -14,7 +14,7 @@ Id := HomalgIdentityMatrix( 3, R );
 
 ZZ := HomalgZeroMatrix( 3, 3, R );
 
-A := UnionOfColumnsOp( Id, -M );
+A := UnionOfColumns( Id, -M );
 
 B := UnionOfRowsOp( 2 * M, Id );
 

--- a/MatricesForHomalg/gap/Basic.gi
+++ b/MatricesForHomalg/gap/Basic.gi
@@ -631,7 +631,7 @@ InstallMethod( LeftDivide,
     ## first reduce A modulo L
     ZA := DecideZeroColumns( A, BL );
     
-    AL := UnionOfColumnsOp( ZA, BL );
+    AL := UnionOfColumns( ZA, BL );
     
     ## AL * CA = IAL
     CA := HomalgVoidMatrix( R );
@@ -952,7 +952,7 @@ InstallGlobalFunction( BestBasis,		### defines: BestBasis
         if m - NrRows( B ) = 0 and n - NrColumns( B ) = 0 then
             return B;
         elif m - NrRows( B ) = 0 and n - NrColumns( B ) > 0 then
-            return UnionOfColumnsOp( B, HomalgZeroMatrix( m, n - NrColumns( B ), R ) );
+            return UnionOfColumns( B, HomalgZeroMatrix( m, n - NrColumns( B ), R ) );
         elif m - NrRows( B ) > 0 and n - NrColumns( B ) = 0 then
             return UnionOfRowsOp( B, HomalgZeroMatrix( m - NrRows( B ), n, R ) );
         else

--- a/MatricesForHomalg/gap/HomalgMatrix.gd
+++ b/MatricesForHomalg/gap/HomalgMatrix.gd
@@ -247,7 +247,7 @@ DeclareProperty( "IsEmptyMatrix",
 ##    <Prop Arg="A" Name="IsDiagonalMatrix"/>
 ##    <Returns><C>true</C> or <C>false</C></Returns>
 ##    <Description>
-##      Check if the &homalg; matrix <A>A</A> is an identity matrix, taking possible ring relations into account.<P/>
+##      Check if the &homalg; matrix <A>A</A> is a diagonal matrix, taking possible ring relations into account.<P/>
 ##      (for the installed standard method see <Ref Meth="IsDiagonalMatrix" Label="homalgTable entry"/>)
 ##    </Description>
 ##  </ManSection>
@@ -1092,17 +1092,14 @@ if not IsBound( UnionOfRows ) then
     BindGlobal( "__INSTALL_UNIONOFROWS_IN_MATRICES", true );
 fi;
 
-DeclareOperation( "UnionOfColumnsOp",
+DeclareOperation( "UnionOfColumnsEager",
         [ IsHomalgMatrix, IsHomalgMatrix ] );
-
-DeclareOperation( "UnionOfColumnsEagerOp",
-        [ IsHomalgMatrix, IsHomalgMatrix ] );
-
-DeclareOperation( "UnionOfColumnsOp",
-        [ IsList, IsHomalgMatrix ] );
-
+        
 if not IsBound( UnionOfColumns ) then
-    DeclareGlobalFunction( "UnionOfColumns" );
+    DeclareOperation( "UnionOfColumns",
+        [ IsHomalgMatrix, IsHomalgMatrix ] );
+    DeclareOperation( "UnionOfColumns",
+        [ IsList ] );
     BindGlobal( "__INSTALL_UNIONOFCOLS_IN_MATRICES", true );
 fi;
 

--- a/MatricesForHomalg/gap/HomalgRingRelations.gi
+++ b/MatricesForHomalg/gap/HomalgRingRelations.gi
@@ -252,7 +252,7 @@ InstallMethod( UnionOfRelations,		### defines: UnionOfRelations (SumRelations)
   function( mat1, rel2 )
     local rel;
     
-    rel := UnionOfColumnsOp( mat1, MatrixOfRelations( rel2 ) );
+    rel := UnionOfColumns( mat1, MatrixOfRelations( rel2 ) );
     
     rel := HomalgRingRelationsAsGeneratorsOfRightIdeal( rel );
     

--- a/MatricesForHomalg/gap/LIMAT.gi
+++ b/MatricesForHomalg/gap/LIMAT.gi
@@ -1183,7 +1183,7 @@ end );
 #-----------------------------------
 
 ##
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "LIMAT: for two homalg matrices (check input)",
         [ IsHomalgMatrix, IsHomalgMatrix ], 10001,
         
@@ -1202,7 +1202,7 @@ InstallMethod( UnionOfColumnsOp,
 end );
 
 ##
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "LIMAT: for two homalg matrices (IsEmptyMatrix)",
         [ IsHomalgMatrix and IsEmptyMatrix, IsHomalgMatrix ],
         
@@ -1215,7 +1215,7 @@ InstallMethod( UnionOfColumnsOp,
 end );
 
 ##
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "LIMAT: for two homalg matrices (IsEmptyMatrix)",
         [ IsHomalgMatrix, IsHomalgMatrix and IsEmptyMatrix ],
         
@@ -1228,7 +1228,7 @@ InstallMethod( UnionOfColumnsOp,
 end );
 
 ## without this method the above two methods will be called in the wrong context!!!
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "LIMAT: for two homalg matrices (IsEmptyMatrix)",
         [ IsHomalgMatrix and IsEmptyMatrix, IsHomalgMatrix and IsEmptyMatrix ],
         
@@ -2788,10 +2788,11 @@ InstallMethod( DecideZeroRowsEffectively,
     ## M = A + T * B
     SetPreEval( T, -CertainColumns( A, nz ) ); ResetFilterObj( T, IsVoidMatrix );
     
-    return UnionOfColumnsOp(
-                   UnionOfColumnsOp( CertainColumns( A, [ 1 .. nz[1] - 1 ] ),
-                           HomalgZeroMatrix( r, l, R ) ),
-                   CertainColumns( A, [ nz[l] + 1 .. c ] ) );
+    return UnionOfColumns( [
+        CertainColumns( A, [ 1 .. nz[1] - 1 ] ),
+        HomalgZeroMatrix( r, l, R ),
+        CertainColumns( A, [ nz[l] + 1 .. c ] )
+        ] );
     
 end );
 

--- a/MatricesForHomalg/gap/LIMATEmp.gi
+++ b/MatricesForHomalg/gap/LIMATEmp.gi
@@ -127,7 +127,7 @@ InstallMethod( \=,
 end );
 
 ##
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "LIMAT: for two homalg matrices (IsEmptyMatrix)",
         [ IsHomalgMatrix and IsEmptyMatrix, IsHomalgMatrix ],
         
@@ -140,7 +140,7 @@ InstallMethod( UnionOfColumnsOp,
 end );
 
 ##
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "LIMAT: for two homalg matrices (IsEmptyMatrix)",
         [ IsHomalgMatrix, IsHomalgMatrix and IsEmptyMatrix ],
         
@@ -153,7 +153,7 @@ InstallMethod( UnionOfColumnsOp,
 end );
 
 ## without this method the above two methods will be called in the wrong context!!!
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "LIMAT: for two homalg matrices (IsEmptyMatrix)",
         [ IsHomalgMatrix and IsEmptyMatrix, IsHomalgMatrix and IsEmptyMatrix ],
         

--- a/MatricesForHomalg/gap/ResidueClassRing.gd
+++ b/MatricesForHomalg/gap/ResidueClassRing.gd
@@ -117,10 +117,10 @@ DeclareOperation( "UnionOfRowsOp",
 DeclareOperation( "UnionOfRowsOp",
         [ IsHomalgMatrix ] );
 
-DeclareOperation( "UnionOfColumnsOp",
+DeclareOperation( "UnionOfColumns",
         [ IsHomalgMatrix, IsHomalgRingRelations ] );
 
-DeclareOperation( "UnionOfColumnsOp",
+DeclareOperation( "UnionOfColumns",
         [ IsHomalgMatrix ] );
 
 DeclareOperation( "DecideZero",

--- a/MatricesForHomalg/gap/ResidueClassRing.gi
+++ b/MatricesForHomalg/gap/ResidueClassRing.gi
@@ -289,7 +289,7 @@ InstallMethod( UnionOfRowsOp,
 end );
 
 ##
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "for homalg residue class matrices",
         [ IsHomalgResidueClassMatrixRep, IsHomalgRingRelations ],
         
@@ -314,18 +314,18 @@ InstallMethod( UnionOfColumnsOp,
     
     rel := DiagMat( ListWithIdenticalEntries( NrRows( M ), rel ) );
     
-    return UnionOfColumnsOp( Eval( M ), rel );
+    return UnionOfColumns( Eval( M ), rel );
     
 end );
 
 ##
-InstallMethod( UnionOfColumnsOp,
+InstallMethod( UnionOfColumns,
         "for homalg residue class matrices",
         [ IsHomalgResidueClassMatrixRep ],
         
   function( M )
     
-    return UnionOfColumnsOp( M, RingRelations( HomalgRing( M ) ) );
+    return UnionOfColumns( M, RingRelations( HomalgRing( M ) ) );
     
 end );
 

--- a/MatricesForHomalg/gap/ResidueClassRingBasic.gi
+++ b/MatricesForHomalg/gap/ResidueClassRingBasic.gi
@@ -55,7 +55,7 @@ InstallValue( CommonHomalgTableForResidueClassRingsBasic,
                  function( M )
                    local Mrel;
                    
-                   Mrel := UnionOfColumnsOp( M );
+                   Mrel := UnionOfColumns( M );
                    
                    Mrel := HomalgResidueClassMatrix(
                                    BasisOfColumnModule( Mrel ), HomalgRing( M ) );
@@ -112,7 +112,7 @@ InstallValue( CommonHomalgTableForResidueClassRingsBasic,
                  function( M, T )
                    local Mrel, TT, bas, nz;
                    
-                   Mrel := UnionOfColumnsOp( M );
+                   Mrel := UnionOfColumns( M );
                    
                    TT := HomalgVoidMatrix( HomalgRing( Mrel ) );
                    
@@ -169,7 +169,7 @@ InstallValue( CommonHomalgTableForResidueClassRingsBasic,
                  function( A, B )
                    local Brel;
                    
-                   Brel := UnionOfColumnsOp( B );
+                   Brel := UnionOfColumns( B );
                    
                    Brel := BasisOfColumnModule( Brel );
                    
@@ -220,7 +220,7 @@ InstallValue( CommonHomalgTableForResidueClassRingsBasic,
                  function( A, B, T )
                    local Brel, TT, red;
                    
-                   Brel := UnionOfColumnsOp( B );
+                   Brel := UnionOfColumns( B );
                    
                    TT := HomalgVoidMatrix( HomalgRing( Brel ) );
                    
@@ -364,7 +364,7 @@ InstallValue( CommonHomalgTableForResidueClassRingsBasic,
                  function( M, M2 )
                    local M2rel, S;
                    
-                   M2rel := UnionOfColumnsOp( M2 );
+                   M2rel := UnionOfColumns( M2 );
                    
                    S := SyzygiesGeneratorsOfColumns( Eval( M ), M2rel );
                    
@@ -402,7 +402,7 @@ InstallValue( CommonHomalgTableForResidueClassRingsBasic,
                  function( M )
                    local Mrel;
                    
-                   Mrel := UnionOfColumnsOp( M );
+                   Mrel := UnionOfColumns( M );
                    
                    Mrel := HomalgResidueClassMatrix( ReducedBasisOfColumnModule( Mrel ), HomalgRing( M ) );
                    

--- a/MatricesForHomalg/gap/ResidueClassRingTools.gi
+++ b/MatricesForHomalg/gap/ResidueClassRingTools.gi
@@ -313,7 +313,7 @@ InstallValue( CommonHomalgTableForResidueClassRingsTools,
                  function( A, B )
                    local N;
                    
-                   N := UnionOfColumnsOp( Eval( A ), Eval( B ) );
+                   N := UnionOfColumns( Eval( A ), Eval( B ) );
                    
                    if not ForAll( [ A, B ], HasIsReducedModuloRingRelations and
                               IsReducedModuloRingRelations ) then

--- a/MatricesForHomalg/gap/Service.gi
+++ b/MatricesForHomalg/gap/Service.gi
@@ -791,7 +791,7 @@ InstallMethod( DecideZeroRows,			### defines: DecideZeroRows (Reduce)
     
     zz := HomalgZeroMatrix( n, l, R );
     
-    M := UnionOfRowsOp( UnionOfColumnsOp( id, A ), UnionOfColumnsOp( zz, B ) );
+    M := UnionOfRowsOp( UnionOfColumns( id, A ), UnionOfColumns( zz, B ) );
     
     M := RowReducedEchelonForm( M );
     
@@ -950,7 +950,7 @@ InstallMethod( DecideZeroColumns,		### defines: DecideZeroColumns (Reduce)
     
     zz := HomalgZeroMatrix( l, n, R );
     
-    M := UnionOfColumnsOp( UnionOfRowsOp( id, A ), UnionOfRowsOp( zz, B ) );
+    M := UnionOfColumns( UnionOfRowsOp( id, A ), UnionOfRowsOp( zz, B ) );
     
     M := ColumnReducedEchelonForm( M );
     
@@ -1410,7 +1410,7 @@ InstallMethod( SyzygiesGeneratorsOfColumns,	### defines: SyzygiesGeneratorsOfCol
     
     #=====# begin of the core procedure #=====#
     
-    M := UnionOfColumnsOp( M1, M2 );
+    M := UnionOfColumns( M1, M2 );
     
     C := SyzygiesGeneratorsOfColumns( M );
     
@@ -2619,7 +2619,7 @@ InstallMethod( DecideZeroRowsEffectively,	### defines: DecideZeroRowsEffectively
     
     zz := HomalgZeroMatrix( n, l, R );
     
-    M := UnionOfRowsOp( UnionOfColumnsOp( id, A ), UnionOfColumnsOp( zz, B ) );
+    M := UnionOfRowsOp( UnionOfColumns( id, A ), UnionOfColumns( zz, B ) );
     
     TT := HomalgVoidMatrix( R );
     
@@ -2801,7 +2801,7 @@ InstallMethod( DecideZeroColumnsEffectively,	### defines: DecideZeroColumnsEffec
     
     zz := HomalgZeroMatrix( l, n, R );
     
-    M := UnionOfColumnsOp( UnionOfRowsOp( id, A ), UnionOfRowsOp( zz, B ) );
+    M := UnionOfColumns( UnionOfRowsOp( id, A ), UnionOfRowsOp( zz, B ) );
     
     TT := HomalgVoidMatrix( R );
     

--- a/Modules/gap/BasicFunctors.gi
+++ b/Modules/gap/BasicFunctors.gi
@@ -649,7 +649,7 @@ InstallGlobalFunction( _Functor_TensorProduct_OnModules,		### defines: TensorPro
         MN := UnionOfRowsOp( matM, matN );
         F := HomalgFreeLeftModule( NrGenerators( M ) * NrGenerators( N ), R );
     else
-        MN := UnionOfColumnsOp( matM, matN );
+        MN := UnionOfColumns( matM, matN );
         F := HomalgFreeRightModule( NrGenerators( M ) * NrGenerators( N ), R );
     fi;
     
@@ -825,7 +825,7 @@ InstallGlobalFunction( _functor_BaseChange_OnModules,		### defines: BaseChange (
             if left then
                 mat := UnionOfRowsOp( mat );
             else
-                mat := UnionOfColumnsOp( mat );
+                mat := UnionOfColumns( mat );
             fi;
         else
             mat := R * mat;

--- a/Modules/gap/HomalgMap.gi
+++ b/Modules/gap/HomalgMap.gi
@@ -498,7 +498,7 @@ InstallMethod( PreInverse,
     
     if IsHomalgLeftObjectOrMorphismOfLeftObjects( phi ) then
         B := HomalgMatrix( B, 1, b * d + c * c, R );
-        A := UnionOfColumnsOp( KroneckerMat( PI, Ib ), KroneckerMat( Ic, p ) );
+        A := UnionOfColumns( KroneckerMat( PI, Ib ), KroneckerMat( Ic, p ) );
         L := DiagMat( [ KroneckerMat( Id, M ), KroneckerMat( Ic, P ) ] );
         sigma := RightDivide( B, A, L );
     else

--- a/Modules/gap/HomalgRelations.gi
+++ b/Modules/gap/HomalgRelations.gi
@@ -466,7 +466,7 @@ InstallMethod( UnionOfRelations,		### defines: UnionOfRelations (SumRelations)
   function( mat1, rel2 )
     local rel;
     
-    rel := UnionOfColumnsOp( mat1, MatrixOfRelations( rel2 ) );
+    rel := UnionOfColumns( mat1, MatrixOfRelations( rel2 ) );
     
     rel := HomalgRelationsForRightModule( rel );
     

--- a/Modules/gap/HomalgSubmodule.gi
+++ b/Modules/gap/HomalgSubmodule.gi
@@ -331,7 +331,7 @@ InstallMethod( IsSubset,
         mapK := BasisOfRowModule( mapK );
         red := DecideZeroRows( mapJ, mapK );
     else
-        mapK := UnionOfColumnsOp( mapK, rel );
+        mapK := UnionOfColumns( mapK, rel );
         mapK := BasisOfColumnModule( mapK );
         red := DecideZeroColumns( mapJ, mapK );
     fi;
@@ -360,7 +360,7 @@ InstallMethod( \+,
     if IsHomalgLeftObjectOrMorphismOfLeftObjects( J ) then
         sum := UnionOfRowsOp( mapK, mapJ );
     else
-        sum := UnionOfColumnsOp( mapK, mapJ );
+        sum := UnionOfColumns( mapK, mapJ );
     fi;
     
     return Subobject( sum, M );

--- a/Modules/gap/OtherFunctors.gi
+++ b/Modules/gap/OtherFunctors.gi
@@ -38,8 +38,8 @@ InstallGlobalFunction( _Functor_DirectSum_OnModules,	### defines: DirectSum
         F := HomalgFreeLeftModule( NrGenerators( M ) + NrGenerators( N ), R );
         zeroMN := HomalgZeroMatrix( NrGenerators( M ), NrGenerators( N ), R );
         zeroNM := HomalgZeroMatrix( NrGenerators( N ), NrGenerators( M ), R );
-        iotaM := UnionOfColumnsOp( idM, zeroMN );
-        iotaN := UnionOfColumnsOp( zeroNM, idN );
+        iotaM := UnionOfColumns( idM, zeroMN );
+        iotaN := UnionOfColumns( zeroNM, idN );
         piM := UnionOfRowsOp( idM, zeroNM );
         piN := UnionOfRowsOp( zeroMN, idN );
     else
@@ -48,8 +48,8 @@ InstallGlobalFunction( _Functor_DirectSum_OnModules,	### defines: DirectSum
         zeroNM := HomalgZeroMatrix( NrGenerators( M ), NrGenerators( N ), R );
         iotaM := UnionOfRowsOp( idM, zeroMN );
         iotaN := UnionOfRowsOp( zeroNM, idN );
-        piM := UnionOfColumnsOp( idM, zeroNM );
-        piN := UnionOfColumnsOp( zeroMN, idN );
+        piM := UnionOfColumns( idM, zeroNM );
+        piN := UnionOfColumns( zeroMN, idN );
     fi;
     
     sum := HomalgMap( sum, "free", F );

--- a/Modules/gap/ToolFunctors.gi
+++ b/Modules/gap/ToolFunctors.gi
@@ -200,7 +200,7 @@ InstallGlobalFunction( _Functor_CoproductMorphism_OnMaps,	### defines: Coproduct
     if IsHomalgLeftObjectOrMorphismOfLeftObjects( phi ) then
         phi_psi := UnionOfRowsOp( MatrixOfMap( phi ), MatrixOfMap( psi ) );
     else
-        phi_psi := UnionOfColumnsOp( MatrixOfMap( phi ), MatrixOfMap( psi ) );
+        phi_psi := UnionOfColumns( MatrixOfMap( phi ), MatrixOfMap( psi ) );
     fi;
     
     SpS := Source( phi ) + Source( psi );
@@ -243,7 +243,7 @@ InstallGlobalFunction( _Functor_ProductMorphism_OnMaps,	### defines: ProductMorp
     fi;
     
     if IsHomalgLeftObjectOrMorphismOfLeftObjects( phi ) then
-        phi_psi := UnionOfColumnsOp( MatrixOfMap( phi ), MatrixOfMap( psi ) );
+        phi_psi := UnionOfColumns( MatrixOfMap( phi ), MatrixOfMap( psi ) );
     else
         phi_psi := UnionOfRowsOp( MatrixOfMap( phi ), MatrixOfMap( psi ) );
     fi;

--- a/Modules/gap/Tools.gi
+++ b/Modules/gap/Tools.gi
@@ -2075,7 +2075,7 @@ InstallMethod( EliminateOverBaseRing,
     
     n := Length( monomsL );
     
-    coeffsL := UnionOfColumnsOp(
+    coeffsL := UnionOfColumns(
                        HomalgIdentityMatrix( n, B ),
                        HomalgZeroMatrix( n, m - n, B )
                        );

--- a/RingsForHomalg/gap/GAPHomalgTools.gi
+++ b/RingsForHomalg/gap/GAPHomalgTools.gi
@@ -140,7 +140,7 @@ InstallValue( CommonHomalgTableForGAPHomalgTools,
                UnionOfColumns :=
                  function( A, B )
                    
-                   return homalgSendBlocking( [ "UnionOfColumnsOp(", A, B, ")" ], HOMALG_IO.Pictograms.UnionOfColumns );
+                   return homalgSendBlocking( [ "UnionOfColumns(", A, B, ")" ], HOMALG_IO.Pictograms.UnionOfColumns );
                    
                  end,
                


### PR DESCRIPTION
(If this works, we can add the same functionality for rows)

 - Got rid of the constructor UnionOfColumnsOp
 - The purity example has the exact same number of external calls
 - No global function is necessary anymore, which removes the
   necessaity of a workaround in connection with the Gauss package
 - Necessary changes (often simplifications) in COLEM
 - The Eval-method is more complicted:
   - The actual union is not done in a tree-like structure with
     trying to do the union for smaller matrices first
   - The matrices are ched whether they are also unevaluated
     unions of rows and then included in the tree structure