### PR TITLE
Fix use of attributes instead of their testers in method filters

### DIFF
--- a/MatricesForHomalg/gap/LIMAT.gi
+++ b/MatricesForHomalg/gap/LIMAT.gi
@@ -524,7 +524,7 @@ end );
 
 ##
 InstallImmediateMethod( ZeroRows,
-        IsHomalgMatrix and EvalCertainRows, 0,
+        IsHomalgMatrix and HasEvalCertainRows, 0,
         
   function( M )
     local e;
@@ -604,7 +604,7 @@ end );
 
 ##
 InstallImmediateMethod( ZeroColumns,
-        IsHomalgMatrix and EvalCertainColumns, 0,
+        IsHomalgMatrix and HasEvalCertainColumns, 0,
         
   function( M )
     local e;

--- a/Modules/gap/GrothendieckGroup.gi
+++ b/Modules/gap/GrothendieckGroup.gi
@@ -206,7 +206,7 @@ end );
 ##
 InstallMethod( ZERO,
         "for an element of the Grothendieck group of a projective space",
-        [ IsElementOfGrothendieckGroupOfProjectiveSpaceRep and AssociatedPolynomial ],
+        [ IsElementOfGrothendieckGroupOfProjectiveSpaceRep and HasAssociatedPolynomial ],
         
   function( P )
     local chi, K_0;


### PR DESCRIPTION
This code was accepted by GAP and silently treated as the same as in the fixed versions; but this will change in a future GAP release.

For details see <https://github.com/gap-system/gap/pull/2732>

It would be kinda cool if this fix could make it into a homalg release before GAP 4.10 is released. But of course that's not much time (a week or so), so we may just end up delaying that fix to GAP 4.11.