### PR TITLE
CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - checkout
       - run: |
+          sudo apt update
+          sudo apt dist-upgrade -y
           sudo apt install -y texlive-latex-extra texlive-science curl
           echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
           make ci-test

--- a/makefile
+++ b/makefile
@@ -20,22 +20,22 @@ docclean:
 test: test_Convex test_Gauss test_ExamplesForHomalg test_GaussForHomalg test_GradedModules test_HomalgToCAS test_GradedRingForHomalg test_IO_ForHomalg test_LocalizeRingForHomalg test_MatricesForHomalg test_RingsForHomalg test_SCO test_ToolsForHomalg test_ToricVarieties test_Modules test_homalg 
 
 ci-test: doc
-	cd Convex; $(MAKE) ci-test; cd -;
-	cd Gauss; $(MAKE) ci-test; cd -;
-	cd ExamplesForHomalg; $(MAKE) ci-test; cd -;
-	cd GaussForHomalg; $(MAKE) ci-test; cd -;
-	cd GradedModules; $(MAKE) ci-test; cd -;
-	cd HomalgToCAS; $(MAKE) ci-test; cd -;
-	cd GradedRingForHomalg; $(MAKE) ci-test; cd -;
-	cd IO_ForHomalg; $(MAKE) ci-test; cd -;
-	cd LocalizeRingForHomalg; $(MAKE) ci-test; cd -;
-	cd MatricesForHomalg; $(MAKE) ci-test; cd -;
-	cd RingsForHomalg; $(MAKE) ci-test; cd -;
-	cd SCO; $(MAKE) ci-test; cd -;
-	cd ToolsForHomalg; $(MAKE) ci-test; cd -;
-	cd ToricVarieties; $(MAKE) ci-test; cd -;
-	cd Modules; $(MAKE) ci-test; cd -;
-	cd homalg; $(MAKE) ci-test; cd -;
+	cd Convex && $(MAKE) ci-test
+	cd Gauss && $(MAKE) ci-test
+	cd ExamplesForHomalg && $(MAKE) ci-test
+	cd GaussForHomalg && $(MAKE) ci-test
+	cd GradedModules && $(MAKE) ci-test
+	cd HomalgToCAS && $(MAKE) ci-test
+	cd GradedRingForHomalg && $(MAKE) ci-test
+	cd IO_ForHomalg && $(MAKE) ci-test
+	cd LocalizeRingForHomalg && $(MAKE) ci-test
+	cd MatricesForHomalg && $(MAKE) ci-test
+	cd RingsForHomalg && $(MAKE) ci-test
+	cd SCO && $(MAKE) ci-test
+	cd ToolsForHomalg && $(MAKE) ci-test
+	cd ToricVarieties && $(MAKE) ci-test
+	cd Modules && $(MAKE) ci-test
+	cd homalg && $(MAKE) ci-test
 
 ############################################
 doc_4ti2Interface:

--- a/makefile
+++ b/makefile
@@ -20,8 +20,10 @@ docclean:
 test: test_Convex test_Gauss test_ExamplesForHomalg test_GaussForHomalg test_GradedModules test_HomalgToCAS test_GradedRingForHomalg test_IO_ForHomalg test_LocalizeRingForHomalg test_MatricesForHomalg test_RingsForHomalg test_SCO test_ToolsForHomalg test_ToricVarieties test_Modules test_homalg 
 
 ci-test: doc
-	cd Convex && $(MAKE) ci-test
-	cd Gauss && $(MAKE) ci-test
+	# requires polymake and polymake interface
+	# cd Convex && $(MAKE) ci-test
+	# no tests
+	# cd Gauss && $(MAKE) ci-test
 	cd ExamplesForHomalg && $(MAKE) ci-test
 	cd GaussForHomalg && $(MAKE) ci-test
 	cd GradedModules && $(MAKE) ci-test
@@ -30,10 +32,13 @@ ci-test: doc
 	cd IO_ForHomalg && $(MAKE) ci-test
 	cd LocalizeRingForHomalg && $(MAKE) ci-test
 	cd MatricesForHomalg && $(MAKE) ci-test
-	cd RingsForHomalg && $(MAKE) ci-test
+	# requires MAGMA
+	# cd RingsForHomalg && $(MAKE) ci-test
 	cd SCO && $(MAKE) ci-test
-	cd ToolsForHomalg && $(MAKE) ci-test
-	cd ToricVarieties && $(MAKE) ci-test
+	# no tests
+	# cd ToolsForHomalg && $(MAKE) ci-test
+	# requires Convex
+	# cd ToricVarieties && $(MAKE) ci-test
 	cd Modules && $(MAKE) ci-test
 	cd homalg && $(MAKE) ci-test
 

--- a/makefile
+++ b/makefile
@@ -22,8 +22,7 @@ test: test_Convex test_Gauss test_ExamplesForHomalg test_GaussForHomalg test_Gra
 ci-test: doc
 	# requires polymake and polymake interface
 	# cd Convex && $(MAKE) ci-test
-	# no tests
-	# cd Gauss && $(MAKE) ci-test
+	cd Gauss && GAPPATH=$$(dirname $$(which gap))/../ ./configure && $(MAKE) && $(MAKE) ci-test
 	cd ExamplesForHomalg && $(MAKE) ci-test
 	cd GaussForHomalg && $(MAKE) ci-test
 	cd GradedModules && $(MAKE) ci-test


### PR DESCRIPTION
CI was broken in several ways:
* Without `apt update` it could not find the most recent version of curl to install.
* It did not actually fail on test errors.
* `Convex` requires polymake and polymake interface.
* `RingsForHomalg` requires MAGMA.
* `ToolsForHomalg` has no tests.
* `ToricVarieties` requires `Convex`.