### PR TITLE
Updated test, documentation and author information in toric varieties

### DIFF
--- a/ToricVarieties/PackageInfo.g
+++ b/ToricVarieties/PackageInfo.g
@@ -43,14 +43,16 @@ rec(
     FirstNames    := "Martin",
     IsAuthor      := true,
     IsMaintainer  := true,
-    Email         := "m.bies@thphys.uni-heidelberg.de",
+    Email         := "martin.bies@alumni.uni-heidelberg.de",
     PostalAddress := Concatenation( [
-                       "Martin Bies\n",
-                       "Philosophenweg 19\n",
-                       "69120 Heidelberg\n",
-                       "Germany" ] ),
-    Place         := "Heidelberg",
-    Institution   := "University of Heidelberg"
+                        "Physique Théorique et Mathématique \n",
+                        "Université Libre de Bruxelles \n",
+                        "Campus Plaine - CP 231 \n",
+                        "Building NO - Level 6 - Office O.6.111 \n",
+                        "1050 Brussels \n",
+                        "Belgium" ] ), 
+    Place         := "Brussels",
+    Institution   := "ULB Brussels"
   ),
 ],
 

--- a/ToricVarieties/doc/Doc.autodoc
+++ b/ToricVarieties/doc/Doc.autodoc
@@ -61,3 +61,6 @@ Sebastian Gutsche
 
 @Subsection Divisors on a toric variety
 @InsertSystem Divisors
+
+@Subsection Polytope of toric divisors
+@InsertSystem PolytopeOfToricDivisor

--- a/ToricVarieties/examples/examplesmanual/PolytopeOfDivisor.g
+++ b/ToricVarieties/examples/examplesmanual/PolytopeOfDivisor.g
@@ -1,0 +1,12 @@
+#! @System PolytopeOfToricDivisor
+
+LoadPackage( "ToricVarieties" );
+
+#! @Example
+P1 := ProjectiveSpace( 1 );
+#! <A projective toric variety of dimension 1>
+divisor := DivisorOfGivenClass( P1, [ -1 ] );
+#! <A divisor of a toric variety with coordinates ( -1, 0 )>
+polytope := PolytopeOfDivisor( divisor );
+#! <A polytope in |R^1>
+#! @EndExample

--- a/ToricVarieties/gap/ToricDivisors.gd
+++ b/ToricVarieties/gap/ToricDivisors.gd
@@ -125,7 +125,7 @@ DeclareAttribute( "BasisOfGlobalSections",
                   IsToricDivisor );
 
 #! @Description
-#!  Returns an integer <A>n</A> such that $n \cdot \text{divi}$ is very ample.
+#!  Returns an integer <A>n</A> such that $n \cdot $divi is very ample.
 #! @Returns an integer
 #! @Arguments divi
 DeclareAttribute( "IntegerForWhichIsSureVeryAmple",


### PR DESCRIPTION
Changes are:

(1) Added PolytopeOfDivisor example, so that tests detect segmentation fault discussed in
https://github.com/homalg-project/homalg_project/issues/223
(2) Documentation builder does not support LaTeX-command "\text"
-> Removed it
(3) Updated PackageInfo.g with my current address, email, ...