### PR TITLE
Improve CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,5 +11,6 @@ jobs:
           sudo apt dist-upgrade -y
           sudo apt install -y texlive-latex-extra texlive-science curl
           echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
+          echo "SetInfoLevel(InfoPackageLoading, 3);" > ~/.gap/gaprc
           make ci-test
           bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  test:
     docker:
       - image: gapsystem/gap-docker:latest
     working_directory: ~/.gap/pkg/homalg_project
@@ -14,3 +14,19 @@ jobs:
           echo "SetInfoLevel(InfoPackageLoading, 3);" > ~/.gap/gaprc
           make ci-test
           bash <(curl -s https://codecov.io/bash)
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - test
+  nightly:
+    triggers:
+      - schedule:
+          # 0:00 UTC = 1:00 CET = 2:00 CEST
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test

--- a/Convex/makefile
+++ b/Convex/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/ExamplesForHomalg/makefile
+++ b/ExamplesForHomalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/Gauss/Makefile.in
+++ b/Gauss/Makefile.in
@@ -52,7 +52,9 @@ test: doc
 	gap -b maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/GaussForHomalg/makefile
+++ b/GaussForHomalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/GradedModules/makefile
+++ b/GradedModules/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/GradedRingForHomalg/makefile
+++ b/GradedRingForHomalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/HomalgToCAS/makefile
+++ b/HomalgToCAS/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/IO_ForHomalg/makefile
+++ b/IO_ForHomalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/LocalizeRingForHomalg/makefile
+++ b/LocalizeRingForHomalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/MatricesForHomalg/gap/HomalgRing.gd
+++ b/MatricesForHomalg/gap/HomalgRing.gd
@@ -928,7 +928,7 @@ DeclareProperty( "IsIrreducibleHomalgRingElement",
 ##  |[ 181 ]|
 ##  gap> s := (1/3*One(R)+2/5)+3/7;
 ##  |[ 106 ]|
-##  gap> 1 / s;
+##  gap> s^(-1);
 ##  fail
 ##  ]]></Example>
 ##    </Description>

--- a/MatricesForHomalg/makefile
+++ b/MatricesForHomalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/Modules/makefile
+++ b/Modules/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/RingsForHomalg/makefile
+++ b/RingsForHomalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/SCO/makefile
+++ b/SCO/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/ToricVarieties/makefile
+++ b/ToricVarieties/makefile
@@ -15,7 +15,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage

--- a/homalg/gap/HomalgComplex.gi
+++ b/homalg/gap/HomalgComplex.gi
@@ -1573,7 +1573,6 @@ end );
 ##  ]]></Example>
 ##  The first possibility:
 ##      <Example><![CDATA[
-##  <A homomorphism of left modules>
 ##  gap> C := HomalgComplex( N );
 ##  <A non-zero graded homology object consisting of a single left module at degre\
 ##  e 0>
@@ -1740,7 +1739,6 @@ end );
 ##  ]]></Example>
 ##  The first possibility:
 ##      <Example><![CDATA[
-##  <A homomorphism of right modules>
 ##  gap> C := HomalgCocomplex( M );
 ##  <A non-zero graded cohomology object consisting of a single right module at de\
 ##  gree 0>

--- a/homalg/makefile
+++ b/homalg/makefile
@@ -14,7 +14,9 @@ test:	doc
 	gap maketest.g
 
 test-with-coverage:	doc
-	! gap --banner --quitonbreak --cover stats maketest.g 2>&1 | grep -v "Running list" | grep ""
+	OUTPUT=$$(gap --banner --quitonbreak --cover stats maketest.g 2>&1); \
+	echo "$$OUTPUT"; \
+	! echo "$$OUTPUT" | grep -v "Running list" | grep -v "^#I  " | grep "" > /dev/null
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 ci-test:	test-with-coverage


### PR DESCRIPTION
Display package loading info for easier debugging if a package fails to load and run tests every night.

Note: the first commit fixes tests failing with GAP 4.10.