### PR TITLE
Specify default test for the Modules package

### DIFF
--- a/Modules/PackageInfo.g
+++ b/Modules/PackageInfo.g
@@ -162,6 +162,8 @@ AvailabilityTest := function()
     return true;
   end,
 
+TestFile := "maketest.g",
+
 Autoload := false,
 
 

--- a/Modules/maketest.g
+++ b/Modules/maketest.g
@@ -1,13 +1,22 @@
 LoadPackage( "AutoDoc" );
 LoadPackage( "Modules" );
 
-dir := DirectoryCurrent( );
+dir := DirectoriesPackageLibrary("Modules","");
+# files with relative paths to the package directory
 files := AUTODOC_FindMatchingFiles( dir,
     ["gap", "examples", "examples/doc" ],
     [ "g", "gi", "gd" ] );
-files := List(files, x -> Concatenation("../", x));
+# files with full paths
+files := List(files, x -> Filename(dir,x));
 
-example_tree := ExtractExamples( Directory("doc/"), "ModulesForHomalg.xml", files, "All" );
-RunExamples( example_tree, rec( compareFunction := "uptowhitespace" ) );
+docdir := DirectoriesPackageLibrary("Modules","doc");
+example_tree := ExtractExamples( docdir, "ModulesForHomalg.xml", files, "All" );
+testresult := RunExamples( example_tree, rec( compareFunction := "uptowhitespace" ) );
 
-QUIT;
+if testresult then
+  Print("#I  No errors detected while testing\n");
+  QUIT_GAP(0);
+else
+  Print("#I  Errors detected while testing\n");
+  QUIT_GAP(1);
+fi;


### PR DESCRIPTION
This comes from https://github.com/gap-packages/gap-packages.github.io/issues/9.

@mohamed-barakat thanks for pointing out that there is already `make test` target. Indeed, 
`gap maketest.g` worked for me, and after adding a line

    TestFile := "maketest.g",

to `PackageInfo.g` I was able to call `TestPackage("Modules");` in GAP and it worked too - but only in when `Modules` is the _current_ directory. Otherwise, e.g, in `make testpackages` or `make testpackage PKGNAME=modules`, it was unable to find paths since they used relative paths.

I have updated `maketest.g` so it now works fine in all possible scenarios, both in `make test` in the package directory, and in tests run by the GAP test suite. It now exits with a proper exit code, and prints a standard string to please failure detection in some scripts that I use elsewhere.

If this looks fine, I will be happy to update this PR and adjust `maketest.g` files for all other packages in this repository. 
 