### PR TITLE
fix the docstring for AffineDimension

### DIFF
--- a/MatricesForHomalg/gap/HomalgMatrix.gd
+++ b/MatricesForHomalg/gap/HomalgMatrix.gd
@@ -771,7 +771,7 @@ DeclareAttribute( "HilbertPolynomial",
 ##  <#GAPDoc Label="AffineDimension">
 ##  <ManSection>
 ##    <Attr Arg="A" Name="AffineDimension"/>
-##    <Returns>a nonnegative integer</Returns>
+##    <Returns>an integer</Returns>
 ##    <Description>
 ##      <A>A</A> is a &homalg; matrix (row convention).
 ##    </Description>


### PR DESCRIPTION
`AffineDimension` does not always return a non-negative integer as illustrated by the following example:

```
LoadPackage("RingsForHomalg");
LoadPackage("Modules");
R := HomalgFieldOfRationalsInSingular()*"x";
AffineDimension(HomalgMatrix("1", 1, 1, R));
```