### PR TITLE
Convenience method for cox ring added

### DIFF
--- a/ToricVarieties/gap/ToricVarieties.gd
+++ b/ToricVarieties/gap/ToricVarieties.gd
@@ -343,12 +343,14 @@ DeclareOperation( "CharacterToRationalFunction",
                   [ IsList, IsToricVariety ] );
 
 #! @Description
-#!  Computes the Cox ring of the variety <A>vari</A>. <A>vars</A> needs to be a string containing one variable,
-#!  which will be numbered by the method. 
+#!  Computes the Cox ring of the variety <A>vari</A>. <A>list</A> is a list of strings. If this list consists
+#! of a single entry, then this string together with an index is used to label the variables of the Cox
+#! ring. Alternatively, <A>list</A> can have as many entries as there are ray generators for this toric 
+#! variety. In this case, the strings in this list are used to label the variables of the Cox ring.
 #! @Returns a ring
-#! @Arguments vari, vars
+#! @Arguments vari, list
 DeclareOperation( "CoxRing",
-                  [ IsToricVariety, IsString ] );
+                  [ IsToricVariety, IsList ] );
 
 #! @Description
 #!  Returns a list of the currently defined Divisors of the toric variety.

--- a/ToricVarieties/gap/ToricVarieties.gd
+++ b/ToricVarieties/gap/ToricVarieties.gd
@@ -426,9 +426,9 @@ DeclareOperation( "ToricVariety",
                   [ IsConvexObject ] );
 
 #! @Description
-#!  Creates a toric variety out of the convex object <A>conv</A>. In addition it takes a list of integers.
+#!  Creates a toric variety out of the convex object <A>conv</A>. In addition it takes a list <A>list</A> of integers.
 #!  Those are used to set the degrees of the variables in the Cox ring of the variety.
 #! @Returns a variety
-#! @Arguments conv
+#! @Arguments conv, list
 DeclareOperation( "ToricVariety",
                   [ IsConvexObject, IsList ] );

--- a/ToricVarieties/gap/ToricVarieties.gd
+++ b/ToricVarieties/gap/ToricVarieties.gd
@@ -432,3 +432,16 @@ DeclareOperation( "ToricVariety",
 #! @Arguments conv, list
 DeclareOperation( "ToricVariety",
                   [ IsConvexObject, IsList ] );
+
+#! @Description
+#! Creates a toric variety from a list <A>rays</A> of ray generators and cones <A>cones</A>.
+#! Beyond the functionality of the other methods, this constructor allows to assign specific 
+#! gradings and homogeneous variable names to the ray generators of this toric variety.
+#! With respect to the order in which the rays appear in the list <A>rays</A>, we assign gradings
+#! and variable names as provided by the third and fourth argument. These are the list of gradings 
+#! <A>degree_list</A> and the list of variables names <A>var_list</A>. The former is a list of 
+#! integers and the latter a list of strings.
+#! @Returns a variety
+#! @Arguments rays, cones, degree_list, var_list
+DeclareOperation( "ToricVariety",
+                  [ IsList, IsList, IsList, IsList ] );

--- a/ToricVarieties/gap/ToricVarieties.gd
+++ b/ToricVarieties/gap/ToricVarieties.gd
@@ -426,12 +426,15 @@ DeclareOperation( "ToricVariety",
                   [ IsConvexObject ] );
 
 #! @Description
-#!  Creates a toric variety out of the convex object <A>conv</A>. In addition it takes a list <A>list</A> of integers.
-#!  Those are used to set the degrees of the variables in the Cox ring of the variety.
+#! Creates a toric variety from a list <A>rays</A> of ray generators and cones <A>cones</A>.
+#! Beyond the functionality of the other methods, this constructor allows to assign specific 
+#! gradings to the homogeneous variables of the Cox ring.
+#! With respect to the order in which the rays appear in the list <A>rays</A>, we assign gradings
+#! as provided by the third argument <A>degree_list</A> . The latter is a list of integers.
 #! @Returns a variety
-#! @Arguments conv, list
+#! @Arguments rays, cones, degree_list
 DeclareOperation( "ToricVariety",
-                  [ IsConvexObject, IsList ] );
+                  [ IsList, IsList, IsList ] );
 
 #! @Description
 #! Creates a toric variety from a list <A>rays</A> of ray generators and cones <A>cones</A>.

--- a/ToricVarieties/gap/ToricVarieties.gi
+++ b/ToricVarieties/gap/ToricVarieties.gi
@@ -542,7 +542,7 @@ InstallMethod( CoxRing,
                
   function( variety )
     
-    return CoxRing( variety, TORIC_VARIETIES.CoxRingIndet );
+    return CoxRing( variety, [ TORIC_VARIETIES.CoxRingIndet ] );
     
 end );
 

--- a/ToricVarieties/gap/ToricVarieties.gi
+++ b/ToricVarieties/gap/ToricVarieties.gi
@@ -1467,12 +1467,12 @@ end );
 ##
 InstallMethod( ToricVariety,
                " for homalg fans and a list of weights for the variables in the Cox ring",
-               [ IsList, IsList ],
+               [ IsList, IsList, IsList ],
   function( rays, cones, degrees )
     local vars;
 
     # install standard list of variable names
-    vars := List( [ 1 .. Length( ray ) ],
+    vars := List( [ 1 .. Length( rays ) ],
                             i -> JoinStringsWithSeparator( [ TORIC_VARIETIES.CoxRingIndet, i ], "_" ) );
 
     # and return result from method below

--- a/ToricVarieties/gap/ToricVarieties.gi
+++ b/ToricVarieties/gap/ToricVarieties.gi
@@ -561,19 +561,46 @@ end );
 RedispatchOnCondition( CoxRing, true, [ IsToricVariety ], [ HasNoTorusfactor ], 0 );
 
 ##
-RedispatchOnCondition( CoxRing, true, [ IsToricVariety, IsString ], [ HasNoTorusfactor ], 0 );
+RedispatchOnCondition( CoxRing, true, [ IsToricVariety, IsList ], [ HasNoTorusfactor ], 0 );
 
 ##
 InstallMethod( CoxRing,
                "for convex toric varieties.",
-               [ IsToricVariety and HasNoTorusfactor, IsString ],
+               [ IsToricVariety and HasNoTorusfactor, IsList ],
                
-  function( variety, variable )
-    local raylist, indeterminates, ring, class_list;
+  function( variety, variable_list )
+    local raylist, i, indeterminates, ring, class_list;
     
     raylist := RayGenerators( FanOfVariety( variety ) );
     
-    indeterminates := List( [ 1 .. Length( raylist ) ], i -> JoinStringsWithSeparator( [ variable, i ], "_" ) );
+    # check that the list of variables consists of strings
+    for i in [ 1 .. Length( variable_list ) ] do
+
+        if not IsString( variable_list[ i ] ) then
+
+            Error( "The list of variables is expected to be a list of strings" );
+            return false;
+
+        fi;
+
+    od;
+
+    # construct list of indeterminates
+    if Length( variable_list ) = 1 then
+
+        indeterminates := List( [ 1 .. Length( raylist ) ], 
+                                          i -> JoinStringsWithSeparator( [ variable_list[ 1 ], i ], "_" ) );
+
+    elif Length( variable_list ) = Length( raylist ) then
+
+        indeterminates := variable_list;
+
+    else
+
+        Error( "The length of list of variables must either be 1 or match the number of ray generators " );
+        return false;
+
+    fi;
 
     indeterminates := JoinStringsWithSeparator( indeterminates, "," );
     

--- a/ToricVarieties/gap/ToricVarieties.gi
+++ b/ToricVarieties/gap/ToricVarieties.gi
@@ -1467,41 +1467,16 @@ end );
 ##
 InstallMethod( ToricVariety,
                " for homalg fans and a list of weights for the variables in the Cox ring",
-               [ IsFan, IsList ],
-  function( fan, degrees )
-    local variety, matrix1, matrix2, map;
+               [ IsList, IsList ],
+  function( rays, cones, degrees )
+    local vars;
 
-    if not IsPointed( fan ) then
+    # install standard list of variable names
+    vars := List( [ 1 .. Length( ray ) ],
+                            i -> JoinStringsWithSeparator( [ TORIC_VARIETIES.CoxRingIndet, i ], "_" ) );
 
-        Error( "input fan must only contain strictly convex cones\n" );
-
-    fi;
-
-    variety := rec( WeilDivisors := WeakPointerObj( [ ] ) );
-
-    ObjectifyWithAttributes(
-                             variety, TheTypeFanToricVariety,
-                             FanOfVariety, fan
-                            );
-
-    # check for valid input
-    matrix1 := Involution( HomalgMatrix( RayGenerators( fan ), HOMALG_MATRICES.ZZ ) );
-    matrix2 := HomalgMatrix( degrees, HOMALG_MATRICES.ZZ );
-    if not IsZero( matrix1 * matrix2 ) then
-
-      Error( "corrupted input - the given weights must form (a) cokernel of the ray generators of the given fan" );
-
-    fi;
-
-    # compute the map from the Weil divisors to the class group according to the given degrees
-    map := HomalgMap( degrees,
-                      TorusInvariantDivisorGroup( variety ),
-                      Length( degrees[ 1 ] ) * HOMALG_MATRICES.ZZ
-                     );
-    SetMapFromWeilDivisorsToClassGroup( variety, map );
-
-    # and return the variety
-    return variety;
+    # and return result from method below
+    return ToricVariety( rays, cones, degrees, vars );
 
 end );
 

--- a/ToricVarieties/gap/ToricVarieties.gi
+++ b/ToricVarieties/gap/ToricVarieties.gi
@@ -1495,6 +1495,20 @@ InstallMethod( ToricVariety,
 
     fi;
 
+    # check that gradings and var_names are of correct lengths
+    if not Length( gradings ) = Length( rays ) then
+
+        Error( "For each ray generators a grading has to be provided" );
+        return false;
+
+    fi;
+    if not Length( var_names ) = Length( rays ) then
+
+        Error( "For each ray generators a variable name has to be provided" );
+        return false;
+
+    fi;
+
     variety := rec( WeilDivisors := WeakPointerObj( [ ] ) );
 
     ObjectifyWithAttributes(


### PR DESCRIPTION
Currently, the variables in Cox rings of toric varieties all carry the names x_i and upon construction of the Cox ring, one can set x to be a prefered string, e.g. "u". However, for Cox rings of say P1 x P1 is makes sense to label the variables as x1, x2, y1, y2. I have adjusted the method Coxring to allow for this feature.

Based on that, I have also added constructors for toric varieties. These allow to set the variables names of the Cox ring by use of the above method. In addition, also the gradings under the class group can be specified.