### PR TITLE
 Convert strings to `IsStringRep` when coercing  if necessary

### DIFF
--- a/MatricesForHomalg/gap/HomalgRing.gd
+++ b/MatricesForHomalg/gap/HomalgRing.gd
@@ -1390,6 +1390,9 @@ DeclareOperation( "/",
         [ IsRingElement, IsHomalgRing ] );
 
 DeclareOperation( "/",
+        [ IsStringRep and IsString, IsHomalgRing ] );
+
+DeclareOperation( "/",
         [ IsString, IsHomalgRing ] );
 
 DeclareGlobalFunction( "StringToElementStringList" );

--- a/MatricesForHomalg/gap/HomalgRing.gi
+++ b/MatricesForHomalg/gap/HomalgRing.gi
@@ -2302,9 +2302,23 @@ end );
 ##
 InstallMethod( \/,
         "for strings",
+        [ IsStringRep and IsString, IsHomalgRing ],
+        
+  function( r, R )
+    
+    return HomalgRingElement( r, R );
+    
+end );
+
+##
+InstallMethod( \/,
+        "for strings",
         [ IsString, IsHomalgRing ],
         
   function( r, R )
+    
+    # IsStringRep( r ) is false since otherwise the method above would have been chosen
+    r := CopyToStringRep( r );
     
     return HomalgRingElement( r, R );
     


### PR DESCRIPTION
The `/` operation accepts arbitrary strings but `HomalgRingElement`
sometimes fails if the string does not lie in `IsStringRep`.

Test case:
```
['1']/HomalgFieldOfRationalsInSingular();
```