### PR TITLE
Turn NrColumns into a synonym for NrCols

### DIFF
--- a/MatricesForHomalg/gap/HomalgMatrix.gd
+++ b/MatricesForHomalg/gap/HomalgMatrix.gd
@@ -514,7 +514,7 @@ DeclareAttribute( "PreEval",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-if not IsBound( NumberRows ) then
+if not IsBound( NrRows ) then
 DeclareAttribute( "NrRows",
         IsHomalgMatrix );
 fi;
@@ -530,13 +530,11 @@ fi;
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-if not IsBound( NumberColumns ) then
-DeclareAttribute( "NrColumns",
+if not IsBound( NrCols ) then
+DeclareAttribute( "NrCols",
         IsHomalgMatrix );
-else
-DeclareSynonymAttr( "NrColumns",
-        ValueGlobal( "NumberColumns" ) );
 fi;
+DeclareSynonymAttr( "NrColumns", NrCols );
 
 ##  <#GAPDoc Label="DeterminantMat">
 ##  <ManSection>


### PR DESCRIPTION
NrCols / NumberColumns is the name used by GAP >= 4.9; this
change ensures that Homalg is compliant with the MatrixObj specification.