### PR TITLE
Fix various "abuses" of filters/properties/attributes

### DIFF
--- a/HomalgToCAS/gap/homalgSendBlocking.gi
+++ b/HomalgToCAS/gap/homalgSendBlocking.gi
@@ -353,7 +353,7 @@ InstallGlobalFunction( homalgCreateStringForExternalCASystem,
                                  return o;
                              else
                                  if IsHomalgExternalMatrixRep( o ) then
-                                     if not ( HasIsVoidMatrix( o ) and IsVoidMatrix( o ) )
+                                     if not IsVoidMatrix( o )
                                         or HasEval( o ) then
                                          t := homalgPointer( o ); ## now we enforce evaluation!!!
                                          Add( used_pointers, t );

--- a/MatricesForHomalg/gap/HomalgMatrix.gd
+++ b/MatricesForHomalg/gap/HomalgMatrix.gd
@@ -49,7 +49,7 @@ DeclareOperation( "SetIsMutableMatrix",
 
 ##  <#GAPDoc Label="IsInitialMatrix">
 ##  <ManSection>
-##    <Prop Arg="A" Name="IsInitialMatrix"/>
+##    <Filt Arg="A" Name="IsInitialMatrix"/>
 ##    <Returns><C>true</C> or <C>false</C></Returns>
 ##    <Description>
 ##      <A>A</A> is a &homalg; matrix.
@@ -57,12 +57,12 @@ DeclareOperation( "SetIsMutableMatrix",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsInitialMatrix",
+DeclareFilter( "IsInitialMatrix",
         IsHomalgMatrix );
 
 ##  <#GAPDoc Label="IsInitialIdentityMatrix">
 ##  <ManSection>
-##    <Prop Arg="A" Name="IsInitialIdentityMatrix"/>
+##    <Filt Arg="A" Name="IsInitialIdentityMatrix"/>
 ##    <Returns><C>true</C> or <C>false</C></Returns>
 ##    <Description>
 ##      <A>A</A> is a &homalg; matrix.
@@ -70,12 +70,12 @@ DeclareProperty( "IsInitialMatrix",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsInitialIdentityMatrix",
+DeclareFilter( "IsInitialIdentityMatrix",
         IsHomalgMatrix );
 
 ##  <#GAPDoc Label="IsVoidMatrix">
 ##  <ManSection>
-##    <Prop Arg="A" Name="IsVoidMatrix"/>
+##    <Filt Arg="A" Name="IsVoidMatrix"/>
 ##    <Returns><C>true</C> or <C>false</C></Returns>
 ##    <Description>
 ##      <A>A</A> is a &homalg; matrix.
@@ -83,7 +83,7 @@ DeclareProperty( "IsInitialIdentityMatrix",
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-DeclareProperty( "IsVoidMatrix",
+DeclareFilter( "IsVoidMatrix",
         IsHomalgMatrix );
 
 ##  <#GAPDoc Label="IsZero:matrix">

--- a/MatricesForHomalg/gap/HomalgMatrix.gi
+++ b/MatricesForHomalg/gap/HomalgMatrix.gi
@@ -3221,11 +3221,11 @@ InstallMethod( ViewString,
     
     str :="";
     
-    if HasIsVoidMatrix( o ) and IsVoidMatrix( o ) then
+    if IsVoidMatrix( o ) then
         Append( str, "<A void" );
-    elif HasIsInitialMatrix( o ) and IsInitialMatrix( o ) then
+    elif IsInitialMatrix( o ) then
         Append( str, "<An initial" );
-    elif HasIsInitialIdentityMatrix( o ) and IsInitialIdentityMatrix( o ) then
+    elif IsInitialIdentityMatrix( o ) then
         Append( str, "<An initial identity" );
     elif not HasEval( o ) then
         Append( str, "<An unevaluated" );

--- a/MatricesForHomalg/gap/HomalgRingRelations.gi
+++ b/MatricesForHomalg/gap/HomalgRingRelations.gi
@@ -79,7 +79,7 @@ InstallMethod( EvaluatedMatrixOfRingRelations,
     
     func_arg := EvalMatrixOfRingRelations( rel );
     
-    ResetFilterObj( rel, EvalMatrixOfRingRelations );
+    ResetFilterObj( rel, HasEvalMatrixOfRingRelations );
     
     ## delete the component which was left over by GAP
     Unbind( rel!.EvalMatrixOfRingRelations );

--- a/MatricesForHomalg/gap/Service.gi
+++ b/MatricesForHomalg/gap/Service.gi
@@ -1315,7 +1315,7 @@ InstallMethod( SyzygiesGeneratorsOfRows,	### defines: SyzygiesGeneratorsOfRows (
         if not IsEmptyMatrix( C ) then
             Eval( C );
         fi;
-        ResetFilterObj( C, EvalCertainColumns );
+        ResetFilterObj( C, HasEvalCertainColumns );
         Unbind( C!.EvalCertainColumns );
     fi;
     
@@ -1435,7 +1435,7 @@ InstallMethod( SyzygiesGeneratorsOfColumns,	### defines: SyzygiesGeneratorsOfCol
         if not IsEmptyMatrix( C ) then
             Eval( C );
         fi;
-        ResetFilterObj( C, EvalCertainRows );
+        ResetFilterObj( C, HasEvalCertainRows );
         Unbind( C!.EvalCertainRows );
     fi;
     

--- a/MatricesForHomalg/gap/Tools.gi
+++ b/MatricesForHomalg/gap/Tools.gi
@@ -395,7 +395,7 @@ InstallMethod( Eval,
     
     func_arg := EvalMatrixOperation( C );
     
-    ResetFilterObj( C, EvalMatrixOperation );
+    ResetFilterObj( C, HasEvalMatrixOperation );
     
     ## delete the component which was left over by GAP
     Unbind( C!.EvalMatrixOperation );
@@ -1665,7 +1665,7 @@ InstallMethod( GetRidOfObsoleteRows,
         if not IsEmptyMatrix( M ) then
             Eval( M );
         fi;
-        ResetFilterObj( M, EvalCertainRows );
+        ResetFilterObj( M, HasEvalCertainRows );
         Unbind( M!.EvalCertainRows );
     fi;
     
@@ -1708,7 +1708,7 @@ InstallMethod( GetRidOfObsoleteColumns,
         if not IsEmptyMatrix( M ) then
             Eval( M );
         fi;
-        ResetFilterObj( M, EvalCertainColumns );
+        ResetFilterObj( M, HasEvalCertainColumns );
         Unbind( M!.EvalCertainColumns );
     fi;
     

--- a/Modules/gap/HomalgRelations.gi
+++ b/Modules/gap/HomalgRelations.gi
@@ -152,7 +152,7 @@ InstallMethod( EvaluatedMatrixOfRelations,
     
     func_arg := EvalMatrixOfRelations( rel );
     
-    ResetFilterObj( rel, EvalMatrixOfRelations );
+    ResetFilterObj( rel, HasEvalMatrixOfRelations );
     
     ## delete the component which was left over by GAP
     Unbind( rel!.EvalMatrixOfRelations );

--- a/Modules/gap/LIMOD.gi
+++ b/Modules/gap/LIMOD.gi
@@ -1770,7 +1770,6 @@ InstallMethod( ProjectiveDimension,
     pd := Length( MorphismDegreesOfComplex( d ) );
     
     if pd < ld then
-        ResetFilterObj( M, AFiniteFreeResolution );
         SetAFiniteFreeResolution( M, d );
     fi;
     

--- a/Modules/gap/Modules.gi
+++ b/Modules/gap/Modules.gi
@@ -444,7 +444,6 @@ InstallMethod( Resolution,
     
     if HasIsRightAcyclic( d ) and IsRightAcyclic( d ) then
         SetFiniteFreeResolutionExists( M, true );
-        ResetFilterObj( M, AFiniteFreeResolution );
         SetAFiniteFreeResolution( M, d );
         rank := Sum( ObjectDegreesOfComplex( d ),
                      i -> (-1)^i *  NrGenerators( CertainObject( d, i ) ) );

--- a/homalg/gap/HomalgFunctor.gd
+++ b/homalg/gap/HomalgFunctor.gd
@@ -158,9 +158,6 @@ DeclareAttribute( "OperationOfFunctor",
 DeclareAttribute( "Genesis",
         IsHomalgFunctor, "mutable" );
 
-DeclareAttribute( "IsIdentityOnObjects",
-        IsHomalgFunctor );
-
 ##  <#GAPDoc Label="ProcedureToReadjustGenerators:functor">
 ##  <ManSection>
 ##    <Attr Arg="Functor" Name="ProcedureToReadjustGenerators" Label="for functors"/>

--- a/homalg/gap/HomalgFunctor.gd
+++ b/homalg/gap/HomalgFunctor.gd
@@ -156,7 +156,7 @@ DeclareAttribute( "OperationOfFunctor",
 ##  <#/GAPDoc>
 ##
 DeclareAttribute( "Genesis",
-        IsHomalgFunctor );
+        IsHomalgFunctor, "mutable" );
 
 DeclareAttribute( "IsIdentityOnObjects",
         IsHomalgFunctor );

--- a/homalg/gap/HomalgFunctor.gi
+++ b/homalg/gap/HomalgFunctor.gi
@@ -6442,7 +6442,6 @@ InstallMethod( InsertObjectInMultiFunctor,
     
     Fp := CallFuncList( CreateHomalgFunctor, data );
     
-    ResetFilterObj( Fp, Genesis );
     SetGenesis( Fp, [ "InsertObjectInMultiFunctor", Functor, p, o ] );
     
     if m > 1 then
@@ -6595,7 +6594,6 @@ InstallMethod( ComposeFunctors,
     
     GF := CallFuncList( CreateHomalgFunctor, data );
     
-    ResetFilterObj( GF, Genesis );
     SetGenesis( GF, [ "ComposeFunctors", [ Functor_post, Functor_pre ], p ] );
     
     if m > 1 then
@@ -6847,7 +6845,6 @@ InstallMethod( RightSatelliteOfCofunctor,
     
     SF := CallFuncList( CreateHomalgFunctor, data );
     
-    ResetFilterObj( SF, Genesis );
     SetGenesis( SF, [ "RightSatelliteOfCofunctor", Functor, p ] );
     
     if m > 1 then
@@ -7088,7 +7085,6 @@ InstallMethod( LeftSatelliteOfFunctor,
     
     SF := CallFuncList( CreateHomalgFunctor, data );
     
-    ResetFilterObj( SF, Genesis );
     SetGenesis( SF, [ "LeftSatelliteOfFunctor", Functor, p ] );
     
     if m > 1 then
@@ -7315,7 +7311,6 @@ InstallMethod( RightDerivedCofunctor,
     
     RF := CallFuncList( CreateHomalgFunctor, data );
     
-    ResetFilterObj( RF, Genesis );
     SetGenesis( RF, [ "RightDerivedCofunctor", Functor, p ] );
     
     if m > 1 then
@@ -7544,7 +7539,6 @@ InstallMethod( LeftDerivedFunctor,
     
     LF := CallFuncList( CreateHomalgFunctor, data );
     
-    ResetFilterObj( LF, Genesis );
     SetGenesis( LF, [ "LeftDerivedFunctor", Functor, p ] );
     
     if m > 1 then

--- a/homalg/gap/HomalgObject.gd
+++ b/homalg/gap/HomalgObject.gd
@@ -273,7 +273,7 @@ DeclareProperty( "HasConstantRank",
 ####################################
 
 DeclareAttribute( "AFiniteFreeResolution",
-        IsHomalgObject );
+        IsHomalgObject, "mutable" );
 
 ##  <#GAPDoc Label="TorsionSubobject">
 ##  <ManSection>

--- a/homalg/gap/StaticObjects.gi
+++ b/homalg/gap/StaticObjects.gi
@@ -558,7 +558,6 @@ InstallMethod( ShortenResolution,
     
     SetCurrentResolution( M, d );
     
-    ResetFilterObj( M, AFiniteFreeResolution );
     SetAFiniteFreeResolution( M, d );
     
     return d;

--- a/homalg/gap/StaticObjects.gi
+++ b/homalg/gap/StaticObjects.gi
@@ -708,7 +708,7 @@ InstallMethod( IntersectWithMultiplicity,
     
     intersection := Iterated( List( [ 1 .. s ], i -> ideals[i]^mults[i] ), Intersect );
     
-    intersection!.Genesis := [ IntersectWithMultiplicity, ideals, mults ];
+    SetGenesis( intersection, [ IntersectWithMultiplicity, ideals, mults ] );
     
     return intersection;
     


### PR DESCRIPTION
There is also some generic code in several which uses `ResetFilterObj` on a bunch of properties and filters, e.g. in `homalgResetFilters`; this is also highly questionable and a potential source of bugs, but I see no way (for me, at least) to change that, as it digs deep into the homalg innards.