### PR TITLE
Revert "Exclude tests for package Modules when testing against GAP ma…

### DIFF
--- a/makefile
+++ b/makefile
@@ -41,9 +41,7 @@ endif
 	# cd ToolsForHomalg && $(MAKE) ci-test
 	# requires Convex
 	# cd ToricVarieties && $(MAKE) ci-test
-ifneq ($(GAP_HOME),/home/gap/inst/gap-master)
 	cd Modules && $(MAKE) ci-test
-endif
 	cd homalg && $(MAKE) ci-test
 
 ############################################


### PR DESCRIPTION
…ster"

This reverts commit 8d91417954d1a8cd875510983b6ad07e682eaf72 now that #277 is fixed.