### PR TITLE
Do not fail for all make targets if GAP_HOME is not set

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ test: test_Convex test_Gauss test_ExamplesForHomalg test_GaussForHomalg test_Gra
 
 ci-test: doc
 ifndef GAP_HOME
-$(error environment variable GAP_HOME is not set)
+	$(error environment variable GAP_HOME is not set)
 endif
 	# requires polymake and polymake interface
 	# cd Convex && $(MAKE) ci-test


### PR DESCRIPTION
Without the indentation the error is displayed no matter which target is called (for example also when calling `make doc`). It should only be displayed for `make ci-test`.