### PR TITLE
Adjust makedoc.g to use a record instead of options

### DIFF
--- a/ToricVarieties/makedoc.g
+++ b/ToricVarieties/makedoc.g
@@ -1,20 +1,22 @@
 LoadPackage( "AutoDoc", "2016.02.16" );
 
-AutoDoc( "ToricVarieties" : scaffold := true, autodoc :=
-             rec( files := [ "doc/Doc.autodoc",
-                         ],
-             scan_dirs := [ "gap", "examples/examplesmanual" ]
-             ),
-         maketest := rec( folder := ".",
-                          commands :=
-                            [ "LoadPackage( \"IO_ForHomalg\" );",
-                              "LoadPackage( \"GaussForHomalg\" );",
-                              "LoadPackage( \"ToricVarieties\" );",
-                              "HOMALG_IO.show_banners := false;",
-                              "HOMALG_IO.suppress_PID := true;",
-                              "HOMALG_IO.use_common_stream := true;",
-                             ]
-                           )
-);
+AutoDoc(rec(
+    scaffold := true,
+    autodoc := rec(
+        files := [ "doc/Doc.autodoc" ],
+        scan_dirs := [ "gap", "examples/examplesmanual" ]
+    ),
+    maketest := rec(
+        folder := ".",
+        commands := [
+            "LoadPackage( \"IO_ForHomalg\" );",
+            "LoadPackage( \"GaussForHomalg\" );",
+            "LoadPackage( \"ToricVarieties\" );",
+            "HOMALG_IO.show_banners := false;",
+            "HOMALG_IO.suppress_PID := true;",
+            "HOMALG_IO.use_common_stream := true;",
+        ]
+    )
+));
 
 QUIT;


### PR DESCRIPTION
ToricVarieties calls AutoDoc an uncommon way (at least in comparison to the other packages in the homalg_project). This leads to subtle differences in a CI environment.