### PR TITLE
Run Jenkins cronjob only on master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 	agent any
 
 	triggers {
-		cron('00 04 * * *')
+		cron(env.BRANCH_NAME == 'master' ? '00 04 * * *' : '')
 	}
 
 	options {


### PR DESCRIPTION
Currently Jenkins builds every branch every night and this takes about 10 hours. Thus, builds triggered in the morning will get queued and not finish until afternoon. I think it suffices to only test the master branch every night.