### PR TITLE
Catching some corner cases in ConvertMatrixToRow/Column

### DIFF
--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -22,6 +22,8 @@ Version := Maximum( [
   "2019.06.04", ## Florian's version
 ## this line prevents merge conflicts
   "2019.11.13", ## Sepp's version
+## this line prevents merge conflicts
+  "2019.12.06", ## Kamal's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/MatricesForHomalg/gap/Tools.gi
+++ b/MatricesForHomalg/gap/Tools.gi
@@ -2678,6 +2678,10 @@ InstallMethod( ConvertMatrixToRow,
     
     R := HomalgRing( M );
     
+    if HasIsZero( M ) and IsZero( M ) then
+        return HomalgZeroMatrix( 1, NrRows( M ) * NrColumns( M ), R );
+    fi;
+    
     RP := homalgTable( R );
     
     if IsBound(RP!.ConvertMatrixToRow) then
@@ -2721,6 +2725,10 @@ InstallMethod( ConvertMatrixToColumn,
     fi;
     
     R := HomalgRing( M );
+    
+    if HasIsZero( M ) and IsZero( M ) then
+        return HomalgZeroMatrix( NrRows( M ) * NrColumns( M ), 1, R );
+    fi;
     
     RP := homalgTable( R );
     


### PR DESCRIPTION
before letting the generic method evalute an empty matrix,
to prevent getting the warning info:

//an empty matrix is about to get evaluated!//