### PR TITLE
Extend the \in method for elements in internal homalg rings

### DIFF
--- a/MatricesForHomalg/gap/HomalgRing.gi
+++ b/MatricesForHomalg/gap/HomalgRing.gi
@@ -1835,6 +1835,10 @@ InstallOtherMethod( \in,
         
   function( z, R )
     
+    if IsBound( R!.ring ) then
+        return z in R!.ring;
+    fi;
+    
     if not IsInt( Zero( R ) ) then
         TryNextMethod( );
     fi;


### PR DESCRIPTION
After this commit we have
```
LoadPackage( "RingsForHomalg" );
k := HomalgRingOfIntegers(5);
One(k) in k;
# true
```
without the commit the output is `false`