### PR TITLE
makedoc.g: require AutoDoc, don't read PackageInfo.g

### DIFF
--- a/4ti2Interface/makedoc.g
+++ b/4ti2Interface/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/Convex/makedoc.g
+++ b/Convex/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/ExamplesForHomalg/makedoc.g
+++ b/ExamplesForHomalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/Gauss/makedoc.g
+++ b/Gauss/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/GaussForHomalg/makedoc.g
+++ b/GaussForHomalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/GradedModules/makedoc.g
+++ b/GradedModules/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/GradedRingForHomalg/makedoc.g
+++ b/GradedRingForHomalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/HomalgToCAS/makedoc.g
+++ b/HomalgToCAS/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/IO_ForHomalg/makedoc.g
+++ b/IO_ForHomalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/LocalizeRingForHomalg/makedoc.g
+++ b/LocalizeRingForHomalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/MatricesForHomalg/makedoc.g
+++ b/MatricesForHomalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/Modules/makedoc.g
+++ b/Modules/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/PolymakeInterface/makedoc.g
+++ b/PolymakeInterface/makedoc.g
@@ -1,11 +1,7 @@
-#
-# Generate the manual using AutoDoc
-#
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/RingsForHomalg/makedoc.g
+++ b/RingsForHomalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/SCO/makedoc.g
+++ b/SCO/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/ToolsForHomalg/makedoc.g
+++ b/ToolsForHomalg/makedoc.g
@@ -4,11 +4,10 @@
 ##  Call this with GAP.
 ##
 
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 

--- a/ToricVarieties/makedoc.g
+++ b/ToricVarieties/makedoc.g
@@ -1,4 +1,6 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
 AutoDoc(rec(
     scaffold := true,

--- a/homalg/makedoc.g
+++ b/homalg/makedoc.g
@@ -1,8 +1,7 @@
-LoadPackage( "AutoDoc", "2016.02.16" );
+if fail = LoadPackage("AutoDoc", ">= 2016.01.21") then
+    Error("AutoDoc 2016.01.21 or newer is required");
+fi;
 
-
-
-Read( "PackageInfo.g" ); 
 PrintTo( "VERSION", GAPInfo.PackageInfoCurrent.Version ); 
 
 


### PR DESCRIPTION
This is just some hopefully harmless cleanup. I was looking at your makedoc.g files for other reasons and notices the `Read( "PackageInfo.g" );` calls which many years ago were perhaps (???) needed but not anymore. Also, it's usually best to actually error out if AutoDoc is missing.