### PR TITLE
Revert "Do not upload code coverage information when testing with gap-master"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           sudo apt install -y texlive-latex-extra texlive-science curl time python-pathlib
           echo "SetInfoLevel(InfoPackageLoading, 3);" > ~/.gap/gaprc
           TERM=dumb make -j 4 --output-sync ci-test
-          [ "$GAP_HOME" != "/home/gap/inst/gap-master" ] && bash <(curl -s https://codecov.io/bash) || true
+          bash <(curl -s https://codecov.io/bash)
 workflows:
   version: 2
   commit:


### PR DESCRIPTION
This reverts commit 12e0cc5738b633c7d1ac1607489cdfa23536d4d3.

Now that GAP 4.11 is released this workaround is no longer necessary.