### PR TITLE
 Turn off Singular's redSB option of DecideZeroRows/ColumnsEffectively 

### DIFF
--- a/ExamplesForHomalg/examples/A3_Purity.g
+++ b/ExamplesForHomalg/examples/A3_Purity.g
@@ -36,13 +36,13 @@
 ##  <A non-pure grade 1 left module presented by 8 relations for 2 generators>>
 ##  gap> II_E := SpectralSequence( filt );
 ##  <A stable homological spectral sequence with sheets at levels 
-##  [ 0 .. 2 ] each consisting of left modules at bidegrees [ -4 .. 0 ]x
+##  [ 0 .. 2 ] each consisting of left modules at bidegrees [ -3 .. 0 ]x
 ##  [ 0 .. 3 ]>
 ##  gap> Display( II_E );
 ##  The associated transposed spectral sequence:
 ##  
 ##  a homological spectral sequence at bidegrees
-##  [ [ 0 .. 3 ], [ -4 .. 0 ] ]
+##  [ [ 0 .. 3 ], [ -3 .. 0 ] ]
 ##  ---------
 ##  Level 0:
 ##  
@@ -50,12 +50,10 @@
 ##   . * * *
 ##   . . * *
 ##   . . . *
-##   . . . *
 ##  ---------
 ##  Level 1:
 ##  
 ##   * * * *
-##   . . . .
 ##   . . . .
 ##   . . . .
 ##   . . . .
@@ -66,33 +64,32 @@
 ##   . . . .
 ##   . . . .
 ##   . . . .
-##   . . . .
 ##  
 ##  Now the spectral sequence of the bicomplex:
 ##  
 ##  a homological spectral sequence at bidegrees
-##  [ [ -4 .. 0 ], [ 0 .. 3 ] ]
+##  [ [ -3 .. 0 ], [ 0 .. 3 ] ]
 ##  ---------
 ##  Level 0:
 ##  
-##   * * * * *
-##   . . * * *
-##   . . . * *
-##   . . . . *
+##   * * * *
+##   . * * *
+##   . . * *
+##   . . . *
 ##  ---------
 ##  Level 1:
 ##  
-##   * * * * *
-##   . . * * *
-##   . . . * *
-##   . . . . .
+##   * * * *
+##   . * * *
+##   . . * *
+##   . . . .
 ##  ---------
 ##  Level 2:
 ##  
-##   . s . . .
-##   . . s . .
-##   . . . s .
-##   . . . . .
+##   s . . .
+##   . s . .
+##   . . s .
+##   . . . .
 ##  gap> m := IsomorphismOfFiltration( filt );
 ##  <A non-zero isomorphism of left modules>
 ##  gap> IsIdenticalObj( Range( m ), N );
@@ -100,12 +97,12 @@
 ##  gap> Source( m );
 ##  <A left module presented by 6 relations for 3 generators (locked)>
 ##  gap> Display( last );
-##  Dx,1/3,1/216*x,
-##  0, Dy, -1/144, 
-##  0, Dx, 1/48,   
-##  0, 0,  Dz,     
-##  0, 0,  Dy,     
-##  0, 0,  Dx      
+##  Dx,1/3,40/9*x,
+##  0, Dy, -20/3, 
+##  0, Dx, 20,    
+##  0, 0,  Dz,    
+##  0, 0,  Dy,    
+##  0, 0,  Dx     
 ##  
 ##  Cokernel of the map
 ##  
@@ -129,9 +126,9 @@
 ##  
 ##  Q[x,y,z]<Dx,Dy,Dz>/< Dz, Dy, Dx >
 ##  gap> Display( m );
-##  1,                     1,      
-##  3*Dz+3,                3*Dz,   
-##  144*Dz^2-144*Dx+144*Dz,144*Dz^2
+##  1,                        1,       
+##  3*Dz+3,                   3*Dz,    
+##  3/20*Dz^2-3/20*Dx+3/20*Dz,3/20*Dz^2
 ##  
 ##  the map is currently represented by the above 3 x 2 matrix
 ##  ]]></Example>

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "HomalgToCAS",
 
 Subtitle := "A window to the outer world",
 
-Version := "2020.06.27",
+Version := "2020.06.28",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/HomalgToCAS/gap/HomalgToCAS.gi
+++ b/HomalgToCAS/gap/HomalgToCAS.gi
@@ -67,6 +67,9 @@ InstallValue( HOMALG_IO,
                 ## memory usage:
                 memory                                  := "mem",
                 
+                ## set option:
+                option                                  := "opt",
+                
                 ## unknown:
                 unknown                                 := "???",
                 

--- a/MatricesForHomalg/gap/Service.gi
+++ b/MatricesForHomalg/gap/Service.gi
@@ -2563,7 +2563,15 @@ InstallMethod( DecideZeroRowsEffectively,	### defines: DecideZeroRowsEffectively
     
     C := HomalgVoidMatrix( R );
     
+    if IsBound( RP!.TurnOffRedSB ) then
+        RP!.TurnOffRedSB( R );
+    fi;
+    
     CB := BasisOfRowsCoeff( B, C );
+    
+    if IsBound( RP!.TurnOnRedSB ) then
+        RP!.TurnOnRedSB( R );
+    fi;
     
     ## knowing this will avoid computations
     IsOne( CB );
@@ -2768,7 +2776,15 @@ InstallMethod( DecideZeroColumnsEffectively,	### defines: DecideZeroColumnsEffec
     
     C := HomalgVoidMatrix( R );
     
+    if IsBound( RP!.TurnOffRedSB ) then
+        RP!.TurnOffRedSB( R );
+    fi;
+    
     BC := BasisOfColumnsCoeff( B, C );
+    
+    if IsBound( RP!.TurnOnRedSB ) then
+        RP!.TurnOnRedSB( R );
+    fi;
     
     ## knowing this will avoid computations
     IsOne( BC );

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -217,7 +217,7 @@ Dependencies := rec(
   GAP := ">=4.7",
   NeededOtherPackages := [
                    [ "MatricesForHomalg", ">= 2020.06.27" ],
-                   [ "HomalgToCAS", ">= 2020.06.27" ],
+                   [ "HomalgToCAS", ">= 2020.06.28" ],
                    [ "GaussForHomalg", ">= 2020.06.27" ],
                    [ "GAPDoc", ">= 1.0" ]
                    ],

--- a/RingsForHomalg/gap/SingularTools.gi
+++ b/RingsForHomalg/gap/SingularTools.gi
@@ -18,6 +18,20 @@
 InstallValue( CommonHomalgTableForSingularTools,
         
         rec(
+               TurnOnRedSB :=
+                 function( R )
+                   
+                   homalgSendBlocking( [ "option(redSB)" ] , "need_command", R, "option" );
+                   
+                 end,
+               
+               TurnOffRedSB :=
+                 function( R )
+                   
+                   homalgSendBlocking( [ "option(noredSB)" ] , "need_command", R, "option" );
+                   
+                 end,
+               
                Zero := HomalgExternalRingElement( R -> homalgSendBlocking( [ "0" ], [ "number" ], R, "Zero" ), "Singular", IsZero ),
                
                One := HomalgExternalRingElement( R -> homalgSendBlocking( [ "1" ], [ "number" ], R, "One" ), "Singular", IsOne ),


### PR DESCRIPTION
The Gröbner basis of B computed by BasisOfRows/ColumnsCoeff is only used
to reduce A to M, and to lift M-A. Both operations do not require the
Gröbner basis to be reduced, if I am not mistaken.

I have an example where the performance drops from 81s to 39s.

The first commit improves the documentation.