### PR TITLE
The method of computing monomials of given degree in graded ring covers now more rings

### DIFF
--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -9,7 +9,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2020.02.05", ## Markus' version
 ## this line prevents merge conflicts
-  "2020.04.15", ## Kamal's version
+  "2020.04.16", ## Kamal's version
 ## this line prevents merge conflicts
   "2019.08.01", ## Max's version
 ## this line prevents merge conflicts
@@ -164,7 +164,9 @@ Dependencies := rec(
                    [ "Modules", ">= 2018.02.04" ],
                    [ "homalg", ">=2011.08.16" ],
                    [ "GAPDoc", ">= 1.0" ] ],
-  SuggestedOtherPackages := [ ],
+  SuggestedOtherPackages := [
+                   [  "NConvex", "2020.03.02" ],
+                   [  "4ti2Interface", "2019.09.03" ] ],
   ExternalConditions := []
                       
 ),

--- a/GradedRingForHomalg/gap/GradedRing.gd
+++ b/GradedRingForHomalg/gap/GradedRing.gd
@@ -139,8 +139,10 @@ DeclareOperation( "HasDegreeGroup",
 DeclareOperation( "SetDegreeGroup",
         [ IsHomalgGradedRing, IsHomalgModule ] );
 
-DeclareOperation( "MonomialsOfDegree",
-        [ IsHomalgGradedRing, IsHomalgModuleElement ] );
+DeclareProperty( "CanComputeMonomialsWithGivenDegreeForRing", IsHomalgGradedRing );
+
+KeyDependentOperation( "MonomialsWithGivenDegree",
+        IsHomalgGradedRing, IsHomalgModuleElement, ReturnTrue );
 
 # constructor methods:
 


### PR DESCRIPTION
As we discussed yesterday, I have added the following adjustments to GradedRingForHomalg

* d&i IsValidRingToComputeMonomialsWithGivenDegree
* operation: MonomialsOfDegree -> key-dependent-operation: MonomialsWithGivenDegree
* add NConvex and 4ti2Interface as suggested packages
* bump version to v2020.04.16