### PR TITLE
Add lazy CoercedMatrix

### DIFF
--- a/MatricesForHomalg/gap/HomalgMatrix.gd
+++ b/MatricesForHomalg/gap/HomalgMatrix.gd
@@ -460,6 +460,9 @@ DeclareAttribute( "EvalTransposedMatrix",
 DeclareAttribute( "ItsTransposedMatrix",
         IsHomalgMatrix );
 
+DeclareAttribute( "EvalCoercedMatrix",
+        IsHomalgMatrix );
+
 DeclareAttribute( "EvalCertainRows",
         IsHomalgMatrix );
 
@@ -1115,6 +1118,9 @@ DeclareOperation( "Involution",
 
 DeclareOperation( "TransposedMatrix",
         [ IsHomalgMatrix ] );
+
+DeclareOperation( "CoercedMatrix",
+        [ IsHomalgMatrix, IsHomalgRing ] );
 
 DeclareOperation( "CertainRows",
         [ IsHomalgMatrix, IsList ] );

--- a/MatricesForHomalg/gap/HomalgMatrix.gi
+++ b/MatricesForHomalg/gap/HomalgMatrix.gi
@@ -1205,7 +1205,17 @@ InstallMethod( UnionOfRowsOp,
         [ IsList, IsHomalgMatrix ],
 
   function( L, M )
-    local result;
+    local result, underlying_union_of_rows;
+
+    if ForAll( L, x -> HasEvalCoercedMatrix( x ) and HomalgRing( EvalCoercedMatrix( x ) ) = HomalgRing( EvalCoercedMatrix( L[1] ) ) ) then
+        
+        #Display("now optimize union of rows");
+        
+        underlying_union_of_rows := UnionOfRows( List( L, x -> EvalCoercedMatrix( x ) ) );
+        
+        return CoercedMatrix( underlying_union_of_rows, HomalgRing(L[1]) );
+        
+    fi;
     
     result := HomalgMatrixWithAttributes( [
          EvalUnionOfRows, L,
@@ -1301,7 +1311,17 @@ InstallMethod( UnionOfColumnsOp,
         [ IsList, IsHomalgMatrix ],
 
   function( L, M )
-    local result;
+    local result, underlying_union_of_columns;
+    
+    if ForAll( L, x -> HasEvalCoercedMatrix( x ) and HomalgRing( EvalCoercedMatrix( x ) ) = HomalgRing( EvalCoercedMatrix( L[1] ) ) ) then
+        
+        #Display("now optimize union of columns");
+        
+        underlying_union_of_columns := UnionOfColumns( List( L, x -> EvalCoercedMatrix( x ) ) );
+        
+        return CoercedMatrix( underlying_union_of_columns, HomalgRing(L[1]) );
+        
+    fi;
     
     result := HomalgMatrixWithAttributes( [
          EvalUnionOfColumns, L,
@@ -3400,6 +3420,25 @@ InstallMethod( \*,
     
     return R * M;
     
+end );
+
+##
+InstallMethod( CoercedMatrix,
+        "for a homalg matrix and a ring",
+        [ IsHomalgMatrix, IsHomalgRing ],
+
+  function( M, new_ring )
+    local C;
+
+    # TODO: Copy properties?
+    C := HomalgMatrixWithAttributes( [
+                 EvalCoercedMatrix, M,
+                 NrRows, NrRows( M ),
+                 NrColumns, NrColumns( M ),
+                 ], new_ring );
+
+    return C;
+
 end );
 
 ##

--- a/MatricesForHomalg/gap/Tools.gi
+++ b/MatricesForHomalg/gap/Tools.gi
@@ -505,6 +505,36 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 
+
+
+InstallMethod( Eval,
+        "for homalg matrices (HasEvalCoercedMatrix)",
+        [ IsHomalgMatrix and HasEvalCoercedMatrix ],
+        
+  function( C )
+    local R, RP, M;
+    
+    #Display("coercening is evaluated");
+    
+    R := HomalgRing( C );
+    
+    RP := homalgTable( R );
+    
+    M := EvalCoercedMatrix( C );
+    
+    if IsBound(RP!.CopyMatrix) then
+
+        Eval(M);
+
+        return RP!.CopyMatrix( M, R );
+        
+    fi;
+    
+    Error( "could not find a procedure called CopyMatrix ",
+           "in the homalgTable of the ring\n" );
+    
+end );
+
 ##  <#GAPDoc Label="TransposedMatrix:homalgTable_entry">
 ##  <ManSection>
 ##    <Func Arg="M" Name="TransposedMatrix" Label="homalgTable entry"/>
@@ -666,7 +696,7 @@ InstallMethod( Eval,
         [ IsHomalgMatrix and HasEvalUnionOfRows ],
         
   function( C )
-    local R, RP, e, i, combine;
+    local R, RP, e, i, combine, underlying_union_of_rows;
     
     R := HomalgRing( C );
     
@@ -674,7 +704,7 @@ InstallMethod( Eval,
     
     # Make it mutable
     e := ShallowCopy( EvalUnionOfRows( C ) );
-    
+
     # In case of nested UnionOfRows, we try to avoid
     # recursion, since the gap stack is rather small
     # additionally unpack PreEvals
@@ -719,6 +749,16 @@ InstallMethod( Eval,
     if Length( e ) = 1 then
         
         return e[1];
+        
+    fi;
+    
+    if ForAll( e, x -> HasEvalCoercedMatrix( x ) and HomalgRing( EvalCoercedMatrix( x ) ) = HomalgRing( EvalCoercedMatrix( e[1] ) ) ) then
+        
+        Display("now optimize union of rows");
+        
+        underlying_union_of_rows := UnionOfRows( List( e, x -> EvalCoercedMatrix( x ) ) );
+        
+        return Eval( CoercedMatrix( underlying_union_of_rows, R ) );
         
     fi;
     
@@ -835,7 +875,7 @@ InstallMethod( Eval,
         [ IsHomalgMatrix and HasEvalUnionOfColumns ],
         
   function( C )
-    local R, RP, e, i, combine;
+    local R, RP, e, i, combine, underlying_union_of_columns;
     
     R := HomalgRing( C );
     
@@ -888,6 +928,16 @@ InstallMethod( Eval,
     if Length( e ) = 1 then
         
         return e[1];
+        
+    fi;
+    
+    if ForAll( e, x -> HasEvalCoercedMatrix( x ) and HomalgRing( EvalCoercedMatrix( x ) ) = HomalgRing( EvalCoercedMatrix( e[1] ) ) ) then
+        
+        Display("now optimize columns");
+        
+        underlying_union_of_columns := UnionOfColumns( List( e, x -> EvalCoercedMatrix( x ) ) );
+        
+        return Eval( CoercedMatrix( underlying_union_of_columns, R ) );
         
     fi;
     


### PR DESCRIPTION
This is a WIP tech demo allowing to coerce matrices lazily.

I currently have an algorithm iterating the following steps:
1. do some computation in a ring `R`
2. coerce the result to another ring `S`
3. take a `UnionOfRows`

Doing the coercion lazily achieves two things:
1. Prevent repeatedly switching between the rings `R` and `S`
2. Instead of coercing each row separately, coerce the union of rows at once

Question: Are there any technical details which I am not aware of which make lazifying things "over different rings" a bad idea?