### PR TITLE
Disable redSB when computing lift in BasisOfRowsCoeff (Singular)

### DIFF
--- a/RingsForHomalg/gap/Singular.gi
+++ b/RingsForHomalg/gap/Singular.gi
@@ -654,14 +654,18 @@ proc PartiallyReducedBasisOfColumnModule (matrix M)\n\
 ##    <Description>
 ##    
 ##      <Listing Type="Code"><![CDATA[
-    BasisOfRowsCoeff := "\n\
-proc BasisOfRowsCoeff (matrix M)\n\
-{\n\
-  matrix B = BasisOfRowModule(M);\n\
-  matrix T = lift(M,B);\n\
-  list l = B,T;\n\
-  return(l)\n\
-}\n\n",
+    BasisOfRowsCoeff := """
+proc BasisOfRowsCoeff (matrix M)
+{
+  matrix B = BasisOfRowModule(M);
+  option(noredSB);
+  matrix T = lift(M,B);
+  option(redSB);
+  list l = B,T;
+  return(l);
+}
+
+ """,
 ##  ]]></Listing>
 ##    </Description>
 ##  </ManSection>


### PR DESCRIPTION
`redSB` does not have any influence on the specification of `lift` but slows down the computation.

This replaces https://github.com/homalg-project/homalg_project/pull/323: it gives the same performance improvement but should be much safer since it does not alter any "real" basis of rows computation. 