### PR TITLE
Fix "method installed for DeterminantMatrix matches more than one declaration"

### DIFF
--- a/MatricesForHomalg/gap/HomalgMatrix.gd
+++ b/MatricesForHomalg/gap/HomalgMatrix.gd
@@ -574,8 +574,10 @@ DeclareSynonymAttr( "NrColumns", NrCols );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
+if not IsBound( DeterminantMatrix ) then
 DeclareAttribute( "DeterminantMat",
         IsHomalgMatrix );
+fi;
 
 ##  <#GAPDoc Label="RowRankOfMatrix">
 ##  <ManSection>


### PR DESCRIPTION
Happens after https://github.com/gap-system/gap/commit/52509bb9811247da6c8ed96c163572d02b6c973d

This should hopefully fix the nightly CI with gap-master.