### PR TITLE
Bump version of all packages and remove "Homepage update versions"

### DIFF
--- a/4ti2Interface/PackageInfo.g
+++ b/4ti2Interface/PackageInfo.g
@@ -10,6 +10,8 @@ Version := Maximum( [
   "2020.07.19", ## Kamal's version
 ## this line prevents merge conflicts
   "2020.05.11", ## Mohamed's version
+## this line prevents merge conflicts
+  "2020.10.01", ## Fabian's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/ExamplesForHomalg/PackageInfo.g
+++ b/ExamplesForHomalg/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "ExamplesForHomalg",
 
 Subtitle := "Examples for the GAP Package homalg",
 
-Version := "2020.05.09",
+Version := "2020.10.01",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/Gauss/PackageInfo.g
+++ b/Gauss/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "Gauss",
 
 Subtitle := "Extended Gauss functionality for GAP",
 
-Version := "2020.06.27",
+Version := "2020.10.01",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/GaussForHomalg/PackageInfo.g
+++ b/GaussForHomalg/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "GaussForHomalg",
 
 Subtitle := "Gauss functionality for the homalg project",
 
-Version := "2020.06.27",
+Version := "2020.10.01",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/GradedModules/PackageInfo.g
+++ b/GradedModules/PackageInfo.g
@@ -19,7 +19,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2014.04.09", ## Max' version
 ## this line prevents merge conflicts
-  "2020.04.17", ## Fabian's version
+  "2020.10.01", ## Fabian's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -23,7 +23,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2019.03.20", ## Sepp's version
 ## this line prevents merge conflicts
-  "2020.06.27", ## Fabian's version
+  "2020.10.01", ## Fabian's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "HomalgToCAS",
 
 Subtitle := "A window to the outer world",
 
-Version := "2020.06.27",
+Version := "2020.10.01",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/IO_ForHomalg/PackageInfo.g
+++ b/IO_ForHomalg/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "IO_ForHomalg",
 
 Subtitle := "IO capabilities for the homalg project",
 
-Version := "2020.04.30",
+Version := "2020.10.01",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/LocalizeRingForHomalg/PackageInfo.g
+++ b/LocalizeRingForHomalg/PackageInfo.g
@@ -15,9 +15,7 @@ Version := Maximum( [ ##To prevent merge conflicts
 ## this line prevents merge conflicts
   "2013.11.11", ## Sebas' version
 ## this line prevents merge conflicts
-  "2020.06.27", ## Fabian's version
-## this line prevents merge conflicts
-"2015.11.06", ## Homepage update version, to be removed
+  "2020.10.01", ## Fabian's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/Modules/PackageInfo.g
+++ b/Modules/PackageInfo.g
@@ -18,6 +18,8 @@ Version := Maximum( [
   "2013.05.05", ## Sepp's version
 ## this line prevents merge conflicts
   "2017.06.19", ## Vinay's version
+## this line prevents merge conflicts
+  "2020.10.01", ## Fabian's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},

--- a/SCO/PackageInfo.g
+++ b/SCO/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "SCO",
 
 Subtitle := "SCO - Simplicial Cohomology of Orbifolds",
 
-Version := "2019.09.02",
+Version := "2020.10.01",
 
 Date := ~.Version{[ 1 .. 10 ]},
 Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),

--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2018.05.22", ## Sebas' version
 ## this line prevents merge conflicts
-  "2020.09.01", ## Fabian's version
+  "2020.10.01", ## Fabian's version
 ## this line prevents merge conflicts
   "2020.09.02", ## Kamal's version
 ## this line prevents merge conflicts

--- a/homalg/PackageInfo.g
+++ b/homalg/PackageInfo.g
@@ -13,7 +13,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2019.09.01", ## Max' version
 ## this line prevents merge conflicts
-"2015.11.05", ## Homepage update version, to be removed
+  "2020.10.01", ## Fabian's version
 ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},


### PR DESCRIPTION
RingsForHomalg and MatricesForHomalg are excluded as they have a release from today.