### PR TITLE
Disable fail-fast in GitHub Actions

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         image: [gapsystem/gap-docker, gapsystem/gap-docker-master]
+      fail-fast: false
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}


### PR DESCRIPTION
Currently, there is no easy way to tell if an error occurs both with `gap-stable` and `gap-master`, or only one of them, because as soon as one job fails, the other one is aborted. This PR disables this behaviour.