### PR TITLE
Apply PackageJanitor and introduce new versioning scheme

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -42,7 +42,7 @@ jobs:
           if [ "${{ matrix.image }}" = "gapsystem/gap-docker" ] && [ "$CUR_SHA" = "$(git rev-parse origin/master)" ] && [ $(dirname "$GITHUB_REPOSITORY") = "homalg-project" ]; then \
             git worktree add gh-pages/ gh-pages || (echo "There was an error. Make sure there is a branch named 'gh-pages'. See https://github.com/homalg-project/PackageJanitor#error-there-was-an-error-make-sure-there-is-a-branch-named-gh-pages"; exit 1); \
             git checkout master; \
-            ./make_dist.sh --token "${{ secrets.GITHUB_TOKEN }}"; \
+            LANG=C.UTF-8 ./make_dist.sh --token "${{ secrets.GITHUB_TOKEN }}"; \
           else \
             echo "Not making a release."; \
           fi

--- a/4ti2Interface/PackageInfo.g
+++ b/4ti2Interface/PackageInfo.g
@@ -5,17 +5,16 @@ PackageName := "4ti2Interface",
 Subtitle := "A link to 4ti2",
 
 Version := Maximum( [
-  "2019.06.02", ## Sebas' version
+  "2019.06-02", ## Sebas' version
 ## this line prevents merge conflicts
-  "2020.07.19", ## Kamal's version
+  "2020.07-19", ## Kamal's version
 ## this line prevents merge conflicts
-  "2020.05.11", ## Mohamed's version
+  "2020.05-11", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2020.10.01", ## Fabian's version
+  "2020.10-02", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/4ti2Interface/README.md
+++ b/4ti2Interface/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# 4ti2Interface – A link to 4ti2
+# 4ti2Interface
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### A link to 4ti2
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/4ti2Interface/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/4ti2Interface/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/ExamplesForHomalg/PackageInfo.g
+++ b/ExamplesForHomalg/PackageInfo.g
@@ -4,10 +4,9 @@ PackageName := "ExamplesForHomalg",
 
 Subtitle := "Examples for the GAP Package homalg",
 
-Version := "2020.10.01",
+Version := "2020.10-02",
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/ExamplesForHomalg/README.md
+++ b/ExamplesForHomalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# ExamplesForHomalg – Examples for the GAP Package homalg
+# ExamplesForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Examples for the GAP Package homalg
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/ExamplesForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/ExamplesForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/Gauss/PackageInfo.g
+++ b/Gauss/PackageInfo.g
@@ -4,10 +4,9 @@ PackageName := "Gauss",
 
 Subtitle := "Extended Gauss functionality for GAP",
 
-Version := "2020.10.01",
+Version := "2020.10-02",
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/Gauss/README.md
+++ b/Gauss/README.md
@@ -1,9 +1,11 @@
 <!-- BEGIN HEADER -->
-# Gauss – Extended Gauss functionality for GAP
+# Gauss
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Extended Gauss functionality for GAP
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 The Gauss package utilizes some C-code by Max Neunhoeffer that has to
@@ -17,8 +19,17 @@ create a makefile. Complete the installation of the package by running
 
     make
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/Gauss/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/Gauss/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/Gauss/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/Gauss/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/Gauss/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/Gauss/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/Gauss/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/GaussForHomalg/PackageInfo.g
+++ b/GaussForHomalg/PackageInfo.g
@@ -4,10 +4,9 @@ PackageName := "GaussForHomalg",
 
 Subtitle := "Gauss functionality for the homalg project",
 
-Version := "2020.10.01",
+Version := "2020.10-02",
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/GaussForHomalg/README.md
+++ b/GaussForHomalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# GaussForHomalg – Gauss functionality for the homalg project
+# GaussForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Gauss functionality for the homalg project
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/GaussForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/GaussForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/GradedModules/PackageInfo.g
+++ b/GradedModules/PackageInfo.g
@@ -5,25 +5,24 @@ PackageName := "GradedModules",
 Subtitle := "A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings",
 
 Version := Maximum( [
-  "2020.04.30", ## Mohamed's version
+  "2020.04-30", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2020.02.05", ## Markus' version
+  "2020.02-05", ## Markus' version
 ## this line prevents merge conflicts
-  "2019.08.01", ## Max's version
+  "2019.08-01", ## Max's version
 ## this line prevents merge conflicts
-  "2011.05.05", ## Sebastian's version
+  "2011.05-05", ## Sebastian's version
 ## this line prevents merge conflicts
-  "2014.07.25", ## Sepp's version
+  "2014.07-25", ## Sepp's version
 ## this line prevents merge conflicts
-  "2015.12.04", ## Sebas' version
+  "2015.12-04", ## Sebas' version
 ## this line prevents merge conflicts
-  "2014.04.09", ## Max' version
+  "2014.04-09", ## Max' version
 ## this line prevents merge conflicts
-  "2020.10.01", ## Fabian's version
+  "2020.10-02", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/GradedModules/README.md
+++ b/GradedModules/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# GradedModules – A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings
+# GradedModules
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/GradedModules/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/GradedModules/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/GradedModules/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/GradedModules/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/GradedModules/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/GradedModules/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/GradedModules/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -5,29 +5,28 @@ PackageName := "GradedRingForHomalg",
 Subtitle := "Endow Commutative Rings with an Abelian Grading",
 
 Version := Maximum( [
-  "2020.05.01", ## Mohamed's version
+  "2020.05-01", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2020.02.05", ## Markus' version
+  "2020.02-05", ## Markus' version
 ## this line prevents merge conflicts
-  "2020.04.16", ## Kamal's version
+  "2020.04-16", ## Kamal's version
 ## this line prevents merge conflicts
-  "2019.08.01", ## Max's version
+  "2019.08-01", ## Max's version
 ## this line prevents merge conflicts
-  "2011.05.05", ## Sebastian's version
+  "2011.05-05", ## Sebastian's version
 ## this line prevents merge conflicts
-  "2015.12.04", ## Sebas' version
+  "2015.12-04", ## Sebas' version
 ## this line prevents merge conflicts
-  "2013.02.07", ## Markus' Kirschmer version
+  "2013.02-07", ## Markus' Kirschmer version
 ## this line prevents merge conflicts
-  "2019.06.04", ## Martin's version
+  "2019.06-04", ## Martin's version
 ## this line prevents merge conflicts
-  "2019.03.20", ## Sepp's version
+  "2019.03-20", ## Sepp's version
 ## this line prevents merge conflicts
-  "2020.10.01", ## Fabian's version
+  "2020.10-02", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/GradedRingForHomalg/README.md
+++ b/GradedRingForHomalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# GradedRingForHomalg – Endow Commutative Rings with an Abelian Grading
+# GradedRingForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Endow Commutative Rings with an Abelian Grading
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/GradedRingForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/GradedRingForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -4,10 +4,9 @@ PackageName := "HomalgToCAS",
 
 Subtitle := "A window to the outer world",
 
-Version := "2020.10.01",
+Version := "2020.10-02",
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/HomalgToCAS/README.md
+++ b/HomalgToCAS/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# HomalgToCAS – A window to the outer world
+# HomalgToCAS
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### A window to the outer world
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/HomalgToCAS/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/HomalgToCAS/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/IO_ForHomalg/PackageInfo.g
+++ b/IO_ForHomalg/PackageInfo.g
@@ -4,10 +4,9 @@ PackageName := "IO_ForHomalg",
 
 Subtitle := "IO capabilities for the homalg project",
 
-Version := "2020.10.01",
+Version := "2020.10-02",
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/IO_ForHomalg/README.md
+++ b/IO_ForHomalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# IO ForHomalg – IO capabilities for the homalg project
+# IO ForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### IO capabilities for the homalg project
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/IO_ForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/IO_ForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/LocalizeRingForHomalg/PackageInfo.g
+++ b/LocalizeRingForHomalg/PackageInfo.g
@@ -5,21 +5,20 @@ PackageName := "LocalizeRingForHomalg",
 Subtitle := "A Package for Localization of Polynomial Rings",
 
 Version := Maximum( [ ##To prevent merge conflicts
-  "2020.04.30", ## Markus' version
+  "2020.04-30", ## Markus' version
 ## this line prevents merge conflicts
-  "2019.09.02", ## Mohamed's version
+  "2019.09-02", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2019.08.01", ## Max's version
+  "2019.08-01", ## Max's version
 ## this line prevents merge conflicts
-  "2013.07.15", ## Vinay's version
+  "2013.07-15", ## Vinay's version
 ## this line prevents merge conflicts
-  "2013.11.11", ## Sebas' version
+  "2013.11-11", ## Sebas' version
 ## this line prevents merge conflicts
-  "2020.10.01", ## Fabian's version
+  "2020.10-02", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/LocalizeRingForHomalg/README.md
+++ b/LocalizeRingForHomalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# LocalizeRingForHomalg – A Package for Localization of Polynomial Rings
+# LocalizeRingForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### A Package for Localization of Polynomial Rings
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -5,29 +5,28 @@ PackageName := "MatricesForHomalg",
 Subtitle := "Matrices for the homalg project",
 
 Version := Maximum( [
-  "2020.09.05", ## Mohamed's version
+  "2020.09-05", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2020.10.02", ## Fabian's version
+  "2020.10-03", ## Fabian's version
 ## this line prevents merge conflicts
-  "2020.02.05", ## Markus' version
+  "2020.02-05", ## Markus' version
 ## this line prevents merge conflicts
-  "2019.09.01", ## Max' version
+  "2019.09-01", ## Max' version
 ## this line prevents merge conflicts
-  "2019.12.03", ## Sebas' version
+  "2019.12-03", ## Sebas' version
 ## this line prevents merge conflicts
-  "2017.07.01", ## Vinay's version
+  "2017.07-01", ## Vinay's version
 ## this line prevents merge conflicts
-  "2013.08.26", ## Martin's version
+  "2013.08-26", ## Martin's version
 ## this line prevents merge conflicts
-  "2019.06.04", ## Florian's version
+  "2019.06-04", ## Florian's version
 ## this line prevents merge conflicts
-  "2020.09.06", ## Sepp's version
+  "2020.09-06", ## Sepp's version
 ## this line prevents merge conflicts
-  "2019.12.06", ## Kamal's version
+  "2019.12-06", ## Kamal's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/MatricesForHomalg/README.md
+++ b/MatricesForHomalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# MatricesForHomalg – Matrices for the homalg project
+# MatricesForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Matrices for the homalg project
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/MatricesForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/MatricesForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/Modules/PackageInfo.g
+++ b/Modules/PackageInfo.g
@@ -5,25 +5,24 @@ PackageName := "Modules",
 Subtitle := "A homalg based package for the Abelian category of finitely presented modules over computable rings",
 
 Version := Maximum( [
-  "2020.05.15", ## Mohamed's version
+  "2020.05-15", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2020.02.05", ## Markus' version
+  "2020.02-05", ## Markus' version
 ## this line prevents merge conflicts
-  "2019.09.01", ## Max's version
+  "2019.09-01", ## Max's version
 ## this line prevents merge conflicts
-  "2011.07.20", ## Florian's version
+  "2011.07-20", ## Florian's version
 ## this line prevents merge conflicts
-  "2018.09.20", ## Sebas' version
+  "2018.09-20", ## Sebas' version
 ## this line prevents merge conflicts
-  "2013.05.05", ## Sepp's version
+  "2013.05-05", ## Sepp's version
 ## this line prevents merge conflicts
-  "2017.06.19", ## Vinay's version
+  "2017.06-19", ## Vinay's version
 ## this line prevents merge conflicts
-  "2020.10.01", ## Fabian's version
+  "2020.10-02", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/Modules/README.md
+++ b/Modules/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# Modules – A homalg based package for the Abelian category of finitely presented modules over computable rings
+# Modules
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### A homalg based package for the Abelian category of finitely presented modules over computable rings
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/Modules/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/Modules/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/Modules/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/Modules/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/Modules/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/Modules/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/Modules/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <!-- BEGIN HEADER -->
-# homalg project – The packages of the homalg project
+# homalg project
+
+### The packages of the homalg project
 
 | Build Status | Code Coverage |
 | ------------ | ------------- |
@@ -26,69 +28,129 @@ This [slideshow](images/homalg-project.pdf) visualizes the interdependency of mo
 </center>
 
 <!-- BEGIN FOOTER -->
-## Packages of [homalg_project](/../../):
+### Packages of [homalg_project](/../../):
 | Name | Description | Documentation |
 | ---- | ----------- | ------------- |
-| [homalg](homalg) | A homological algebra meta-package for computable Abelian categories | [![HTML stable documentation][docs-homalg-img]][docs-homalg-url] |
-| [4ti2Interface](4ti2Interface) | A link to 4ti2 | [![HTML stable documentation][docs-4ti2Interface-img]][docs-4ti2Interface-url] |
-| [ExamplesForHomalg](ExamplesForHomalg) | Examples for the GAP Package homalg | [![HTML stable documentation][docs-ExamplesForHomalg-img]][docs-ExamplesForHomalg-url] |
-| [Gauss](Gauss) | Extended Gauss functionality for GAP | [![HTML stable documentation][docs-Gauss-img]][docs-Gauss-url] |
-| [GaussForHomalg](GaussForHomalg) | Gauss functionality for the homalg project | [![HTML stable documentation][docs-GaussForHomalg-img]][docs-GaussForHomalg-url] |
-| [GradedModules](GradedModules) | A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings | [![HTML stable documentation][docs-GradedModules-img]][docs-GradedModules-url] |
-| [GradedRingForHomalg](GradedRingForHomalg) | Endow Commutative Rings with an Abelian Grading | [![HTML stable documentation][docs-GradedRingForHomalg-img]][docs-GradedRingForHomalg-url] |
-| [HomalgToCAS](HomalgToCAS) | A window to the outer world | [![HTML stable documentation][docs-HomalgToCAS-img]][docs-HomalgToCAS-url] |
-| [IO_ForHomalg](IO_ForHomalg) | IO capabilities for the homalg project | [![HTML stable documentation][docs-IO_ForHomalg-img]][docs-IO_ForHomalg-url] |
-| [LocalizeRingForHomalg](LocalizeRingForHomalg) | A Package for Localization of Polynomial Rings | [![HTML stable documentation][docs-LocalizeRingForHomalg-img]][docs-LocalizeRingForHomalg-url] |
-| [MatricesForHomalg](MatricesForHomalg) | Matrices for the homalg project | [![HTML stable documentation][docs-MatricesForHomalg-img]][docs-MatricesForHomalg-url] |
-| [Modules](Modules) | A homalg based package for the Abelian category of finitely presented modules over computable rings | [![HTML stable documentation][docs-Modules-img]][docs-Modules-url] |
-| [RingsForHomalg](RingsForHomalg) | Dictionaries of external rings | [![HTML stable documentation][docs-RingsForHomalg-img]][docs-RingsForHomalg-url] |
-| [SCO](SCO) | SCO - Simplicial Cohomology of Orbifolds | [![HTML stable documentation][docs-SCO-img]][docs-SCO-url] |
-| [ToolsForHomalg](ToolsForHomalg) | Special methods and knowledge propagation tools | [![HTML stable documentation][docs-ToolsForHomalg-img]][docs-ToolsForHomalg-url] |
+| [homalg](homalg) | A homological algebra meta-package for computable Abelian categories | [![HTML stable documentation][html-homalg-img]][html-homalg-url] [![PDF stable documentation][pdf-homalg-img]][pdf-homalg-url] |
+| [4ti2Interface](4ti2Interface) | A link to 4ti2 | [![HTML stable documentation][html-4ti2Interface-img]][html-4ti2Interface-url] [![PDF stable documentation][pdf-4ti2Interface-img]][pdf-4ti2Interface-url] |
+| [ExamplesForHomalg](ExamplesForHomalg) | Examples for the GAP Package homalg | [![HTML stable documentation][html-ExamplesForHomalg-img]][html-ExamplesForHomalg-url] [![PDF stable documentation][pdf-ExamplesForHomalg-img]][pdf-ExamplesForHomalg-url] |
+| [Gauss](Gauss) | Extended Gauss functionality for GAP | [![HTML stable documentation][html-Gauss-img]][html-Gauss-url] [![PDF stable documentation][pdf-Gauss-img]][pdf-Gauss-url] |
+| [GaussForHomalg](GaussForHomalg) | Gauss functionality for the homalg project | [![HTML stable documentation][html-GaussForHomalg-img]][html-GaussForHomalg-url] [![PDF stable documentation][pdf-GaussForHomalg-img]][pdf-GaussForHomalg-url] |
+| [GradedModules](GradedModules) | A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings | [![HTML stable documentation][html-GradedModules-img]][html-GradedModules-url] [![PDF stable documentation][pdf-GradedModules-img]][pdf-GradedModules-url] |
+| [GradedRingForHomalg](GradedRingForHomalg) | Endow Commutative Rings with an Abelian Grading | [![HTML stable documentation][html-GradedRingForHomalg-img]][html-GradedRingForHomalg-url] [![PDF stable documentation][pdf-GradedRingForHomalg-img]][pdf-GradedRingForHomalg-url] |
+| [HomalgToCAS](HomalgToCAS) | A window to the outer world | [![HTML stable documentation][html-HomalgToCAS-img]][html-HomalgToCAS-url] [![PDF stable documentation][pdf-HomalgToCAS-img]][pdf-HomalgToCAS-url] |
+| [IO_ForHomalg](IO_ForHomalg) | IO capabilities for the homalg project | [![HTML stable documentation][html-IO_ForHomalg-img]][html-IO_ForHomalg-url] [![PDF stable documentation][pdf-IO_ForHomalg-img]][pdf-IO_ForHomalg-url] |
+| [LocalizeRingForHomalg](LocalizeRingForHomalg) | A Package for Localization of Polynomial Rings | [![HTML stable documentation][html-LocalizeRingForHomalg-img]][html-LocalizeRingForHomalg-url] [![PDF stable documentation][pdf-LocalizeRingForHomalg-img]][pdf-LocalizeRingForHomalg-url] |
+| [MatricesForHomalg](MatricesForHomalg) | Matrices for the homalg project | [![HTML stable documentation][html-MatricesForHomalg-img]][html-MatricesForHomalg-url] [![PDF stable documentation][pdf-MatricesForHomalg-img]][pdf-MatricesForHomalg-url] |
+| [Modules](Modules) | A homalg based package for the Abelian category of finitely presented modules over computable rings | [![HTML stable documentation][html-Modules-img]][html-Modules-url] [![PDF stable documentation][pdf-Modules-img]][pdf-Modules-url] |
+| [RingsForHomalg](RingsForHomalg) | Dictionaries of external rings | [![HTML stable documentation][html-RingsForHomalg-img]][html-RingsForHomalg-url] [![PDF stable documentation][pdf-RingsForHomalg-img]][pdf-RingsForHomalg-url] |
+| [SCO](SCO) | SCO - Simplicial Cohomology of Orbifolds | [![HTML stable documentation][html-SCO-img]][html-SCO-url] [![PDF stable documentation][pdf-SCO-img]][pdf-SCO-url] |
+| [ToolsForHomalg](ToolsForHomalg) | Special methods and knowledge propagation tools | [![HTML stable documentation][html-ToolsForHomalg-img]][html-ToolsForHomalg-url] [![PDF stable documentation][pdf-ToolsForHomalg-img]][pdf-ToolsForHomalg-url] |
 
-[docs-homalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-homalg-url]: https://homalg-project.github.io/homalg_project/homalg/doc/chap0_mj.html
+[html-homalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-homalg-url]: https://homalg-project.github.io/homalg_project/homalg/doc/chap0_mj.html
 
-[docs-4ti2Interface-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-4ti2Interface-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/doc/chap0_mj.html
+[pdf-homalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-homalg-url]: https://homalg-project.github.io/homalg_project/homalg/download_pdf.html
 
-[docs-ExamplesForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-ExamplesForHomalg-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/doc/chap0_mj.html
 
-[docs-Gauss-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-Gauss-url]: https://homalg-project.github.io/homalg_project/Gauss/doc/chap0_mj.html
+[html-4ti2Interface-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-4ti2Interface-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/doc/chap0_mj.html
 
-[docs-GaussForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-GaussForHomalg-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/doc/chap0_mj.html
+[pdf-4ti2Interface-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-4ti2Interface-url]: https://homalg-project.github.io/homalg_project/4ti2Interface/download_pdf.html
 
-[docs-GradedModules-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-GradedModules-url]: https://homalg-project.github.io/homalg_project/GradedModules/doc/chap0_mj.html
 
-[docs-GradedRingForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-GradedRingForHomalg-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/doc/chap0_mj.html
+[html-ExamplesForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-ExamplesForHomalg-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/doc/chap0_mj.html
 
-[docs-HomalgToCAS-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-HomalgToCAS-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/doc/chap0_mj.html
+[pdf-ExamplesForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-ExamplesForHomalg-url]: https://homalg-project.github.io/homalg_project/ExamplesForHomalg/download_pdf.html
 
-[docs-IO_ForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-IO_ForHomalg-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/doc/chap0_mj.html
 
-[docs-LocalizeRingForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-LocalizeRingForHomalg-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/doc/chap0_mj.html
+[html-Gauss-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-Gauss-url]: https://homalg-project.github.io/homalg_project/Gauss/doc/chap0_mj.html
 
-[docs-MatricesForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-MatricesForHomalg-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/doc/chap0_mj.html
+[pdf-Gauss-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-Gauss-url]: https://homalg-project.github.io/homalg_project/Gauss/download_pdf.html
 
-[docs-Modules-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-Modules-url]: https://homalg-project.github.io/homalg_project/Modules/doc/chap0_mj.html
 
-[docs-RingsForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-RingsForHomalg-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/doc/chap0_mj.html
+[html-GaussForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-GaussForHomalg-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/doc/chap0_mj.html
 
-[docs-SCO-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-SCO-url]: https://homalg-project.github.io/homalg_project/SCO/doc/chap0_mj.html
+[pdf-GaussForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-GaussForHomalg-url]: https://homalg-project.github.io/homalg_project/GaussForHomalg/download_pdf.html
 
-[docs-ToolsForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-ToolsForHomalg-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/doc/chap0_mj.html
+
+[html-GradedModules-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-GradedModules-url]: https://homalg-project.github.io/homalg_project/GradedModules/doc/chap0_mj.html
+
+[pdf-GradedModules-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-GradedModules-url]: https://homalg-project.github.io/homalg_project/GradedModules/download_pdf.html
+
+
+[html-GradedRingForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-GradedRingForHomalg-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/doc/chap0_mj.html
+
+[pdf-GradedRingForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-GradedRingForHomalg-url]: https://homalg-project.github.io/homalg_project/GradedRingForHomalg/download_pdf.html
+
+
+[html-HomalgToCAS-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-HomalgToCAS-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/doc/chap0_mj.html
+
+[pdf-HomalgToCAS-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-HomalgToCAS-url]: https://homalg-project.github.io/homalg_project/HomalgToCAS/download_pdf.html
+
+
+[html-IO_ForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-IO_ForHomalg-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/doc/chap0_mj.html
+
+[pdf-IO_ForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-IO_ForHomalg-url]: https://homalg-project.github.io/homalg_project/IO_ForHomalg/download_pdf.html
+
+
+[html-LocalizeRingForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-LocalizeRingForHomalg-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/doc/chap0_mj.html
+
+[pdf-LocalizeRingForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-LocalizeRingForHomalg-url]: https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/download_pdf.html
+
+
+[html-MatricesForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-MatricesForHomalg-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/doc/chap0_mj.html
+
+[pdf-MatricesForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-MatricesForHomalg-url]: https://homalg-project.github.io/homalg_project/MatricesForHomalg/download_pdf.html
+
+
+[html-Modules-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-Modules-url]: https://homalg-project.github.io/homalg_project/Modules/doc/chap0_mj.html
+
+[pdf-Modules-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-Modules-url]: https://homalg-project.github.io/homalg_project/Modules/download_pdf.html
+
+
+[html-RingsForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-RingsForHomalg-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/doc/chap0_mj.html
+
+[pdf-RingsForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-RingsForHomalg-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/download_pdf.html
+
+
+[html-SCO-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-SCO-url]: https://homalg-project.github.io/homalg_project/SCO/doc/chap0_mj.html
+
+[pdf-SCO-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-SCO-url]: https://homalg-project.github.io/homalg_project/SCO/download_pdf.html
+
+
+[html-ToolsForHomalg-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-ToolsForHomalg-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/doc/chap0_mj.html
+
+[pdf-ToolsForHomalg-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-ToolsForHomalg-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/download_pdf.html
+
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -5,25 +5,23 @@ PackageName := "RingsForHomalg",
 Subtitle := "Dictionaries of external rings",
 
 Version := Maximum( [
-  "2020.10.03", ## Mohamed's version
+  "2020.10-03", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2020.02.05", ## Markus L-H's version
+  "2020.02-05", ## Markus L-H's version
 ## this line prevents merge conflicts
-  "2017.04.17", ## Markus K's version
+  "2017.04-17", ## Markus K's version
 ## this line prevents merge conflicts
-  "2011.12.13", ## Andreas's version
+  "2011.12-13", ## Andreas's version
 ## this line prevents merge conflicts
-  "2019.09.01", ## Sebas' version
+  "2019.09-01", ## Sebas' version
 ## this line prevents merge conflicts
-  "2013.07.16", ## Vinay's version
+  "2013.07-16", ## Vinay's version
 ## this line prevents merge conflicts
-  "2020.10.02", ## Fabian's version
+  "2020.10-04", ## Fabian's version
 ## this line prevents merge conflicts
-"2015.11.06", ## Homepage update version, to be removed
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/RingsForHomalg/README.md
+++ b/RingsForHomalg/README.md
@@ -1,9 +1,11 @@
 <!-- BEGIN HEADER -->
-# RingsForHomalg – Dictionaries of external rings
+# RingsForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Dictionaries of external rings
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 This package gives access to certain classes of rings and matrices from the computer algebra systems
@@ -29,8 +31,17 @@ And starting from version 10 something like:
 sudo ln -s /Library/Frameworks/Maple.framework/Versions/13/bin/maple /usr/local/bin/maple13
 ```
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/RingsForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/RingsForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/RingsForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/SCO/PackageInfo.g
+++ b/SCO/PackageInfo.g
@@ -4,10 +4,9 @@ PackageName := "SCO",
 
 Subtitle := "SCO - Simplicial Cohomology of Orbifolds",
 
-Version := "2020.10.01",
+Version := "2020.10-02",
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/SCO/README.md
+++ b/SCO/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# SCO – SCO - Simplicial Cohomology of Orbifolds
+# SCO
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### SCO - Simplicial Cohomology of Orbifolds
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/SCO/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/SCO/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/SCO/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/SCO/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/SCO/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/SCO/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/SCO/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -5,21 +5,20 @@ PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
 
 Version := Maximum( [
-  "2020.09.06", ## Mohamed's version
+  "2020.09-06", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2011.09.12", ## Markus' version
+  "2011.09-12", ## Markus' version
 ## this line prevents merge conflicts
-  "2018.05.22", ## Sebas' version
+  "2018.05-22", ## Sebas' version
 ## this line prevents merge conflicts
-  "2020.10.01", ## Fabian's version
+  "2020.10-02", ## Fabian's version
 ## this line prevents merge conflicts
-  "2020.09.02", ## Kamal's version
+  "2020.09-02", ## Kamal's version
 ## this line prevents merge conflicts
 
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/README.md
+++ b/ToolsForHomalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# ToolsForHomalg – Special methods and knowledge propagation tools
+# ToolsForHomalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### Special methods and knowledge propagation tools
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/ToolsForHomalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/ToolsForHomalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/ToolsForHomalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/homalg/PackageInfo.g
+++ b/homalg/PackageInfo.g
@@ -5,19 +5,18 @@ PackageName := "homalg",
 Subtitle := "A homological algebra meta-package for computable Abelian categories",
 
 Version := Maximum( [
-  "2020.04.30", ## Mohamed's version
+  "2020.04-30", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2012.09.17", ## Markus' version
+  "2012.09-17", ## Markus' version
 ## this line prevents merge conflicts
-  "2012.03.29", ## Sebas' version
+  "2012.03-29", ## Sebas' version
 ## this line prevents merge conflicts
-  "2019.09.01", ## Max' version
+  "2019.09-01", ## Max' version
 ## this line prevents merge conflicts
-  "2020.10.01", ## Fabian's version
+  "2020.10-02", ## Fabian's version
 ] ),
 
-Date := ~.Version{[ 1 .. 10 ]},
-Date := Concatenation( ~.Date{[ 9, 10 ]}, "/", ~.Date{[ 6, 7 ]}, "/", ~.Date{[ 1 .. 4 ]} ),
+Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 
 License := "GPL-2.0-or-later",
 

--- a/homalg/README.md
+++ b/homalg/README.md
@@ -1,14 +1,25 @@
 <!-- BEGIN HEADER -->
-# homalg – A homological algebra meta-package for computable Abelian categories
+# homalg
 
-| Documentation | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
-| ------------- | ------------ | ------------- |
-| [![HTML stable documentation][docs-img]][docs-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
+### A homological algebra meta-package for computable Abelian categories
+
+| Documentation | Latest Release | Build Status of [homalg_project](/../../) | Code Coverage of [homalg_project](/../../) |
+| ------------- | -------------- | ------------ | ------------- |
+| [![HTML stable documentation][html-img]][html-url] [![PDF stable documentation][pdf-img]][pdf-url] | [![version][version-img]][version-url] [![date][date-img]][date-url] | [![Build Status][tests-img]][tests-url] | [![Code Coverage][codecov-img]][codecov-url] |
 
 <!-- END HEADER -->
 <!-- BEGIN FOOTER -->
-[docs-img]: https://img.shields.io/badge/HTML-stable-blue.svg
-[docs-url]: https://homalg-project.github.io/homalg_project/homalg/doc/chap0_mj.html
+[html-img]: https://img.shields.io/badge/HTML-stable-blue.svg
+[html-url]: https://homalg-project.github.io/homalg_project/homalg/doc/chap0_mj.html
+
+[pdf-img]: https://img.shields.io/badge/PDF-stable-blue.svg
+[pdf-url]: https://homalg-project.github.io/homalg_project/homalg/download_pdf.html
+
+[version-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/homalg/badge_version.json
+[version-url]: https://homalg-project.github.io/homalg_project/homalg/view_release.html
+
+[date-img]: https://img.shields.io/endpoint?url=https://homalg-project.github.io/homalg_project/homalg/badge_date.json
+[date-url]: https://homalg-project.github.io/homalg_project/homalg/view_release.html
 
 [tests-img]: https://github.com/homalg-project/homalg_project/workflows/Tests/badge.svg?branch=master
 [tests-url]: https://github.com/homalg-project/homalg_project/actions?query=workflow%3ATests+branch%3Amaster

--- a/release-gap-package
+++ b/release-gap-package
@@ -244,6 +244,7 @@ else
     tmp := GAPInfo.PackageInfoCurrent.ArchiveURL;
     Print("GAP_ERROR=\"The ArchiveURL has unexpected value '",tmp,"'\"\n");
 fi;
+Print("PDFFile=\"",GAPInfo.PackageInfoCurrent.PackageDoc.PDFFile,"\"\n");
 EOF
 
 # evaluate the output of GAP, which should be valid shell script code
@@ -407,6 +408,13 @@ git archive --prefix="$BASENAME/" "$TAG" . | tar xf - -C "$TMP_DIR"
 # Build the package documentation, run autoconf, etc.
 cd "$TMP_DIR/$BASENAME"
 
+# adjust date
+# Note that we cannot use sed's `-i` option for in-place editing, as
+# that is a non-portable extension of POSIX, which works differently in
+# BSD and GNU make.
+sed "s;Date := .*;Date := \"$(date +%d/%m/%Y)\",;" PackageInfo.g > PackageInfo.g.bak
+mv PackageInfo.g.bak PackageInfo.g
+
 notice "Removing unnecessary files"
 rm -rf .github .circleci
 rm -f .git* .hg* .cvs*
@@ -451,9 +459,23 @@ fi
 # make sure every file is readable
 chmod -R a+r .
 
+# adjust links to other manuals
+# Note that we cannot use sed's `-i` option for in-place editing, as
+# that is a non-portable extension of POSIX, which works differently in
+# BSD and GNU make.
+for f in ./*/*.htm* ; do
+  sed 's;href="/home/gap/.gap/pkg/homalg_project/Modules/doc/;href="https://homalg-project.github.io/homalg_project/Modules/doc/;g' "$f" > "$f.bak"
+  mv "$f.bak" "$f"
+done
+
+for f in ./*/*.htm* ; do
+  sed 's;href="/home/gap/.gap/pkg/homalg_project/homalg/doc/;href="https://homalg-project.github.io/homalg_project/homalg/doc/;g' "$f" > "$f.bak"
+  mv "$f.bak" "$f"
+done
+
 # basic sanity check
-#fgrep -q -r '<a href="/' */*.htm* &&
-#    error "HTML manual contains absolute paths"
+fgrep -q -r '<a href="/' */*.htm* &&
+    error "HTML manual contains absolute paths"
 
 
 ######################################################################
@@ -591,6 +613,26 @@ for EXT in $ARCHIVE_FORMATS ; do
         -H "Content-Type: $MIMETYPE" \
         --data-binary @"$FULLNAME")
 done
+
+
+######################################################################
+#
+# Upload PDF
+#
+cd "$TMP_DIR"
+echo ""
+
+FULLNAME="$TMP_DIR/$BASENAME/$PDFFile"
+if [ ! -f "$FULLNAME" ] ; then
+	error "could not find PDF"
+fi
+notice "Uploading PDF"
+response=$(curl --fail --progress-bar -o "$TMP_DIR/upload.log" \
+	-X POST "$UPLOAD_URL/$RELEASE_ID/assets?name=$BASENAME.pdf" \
+	-H "Accept: application/vnd.github.v3+json" \
+	-H "Authorization: token $TOKEN" \
+	-H "Content-Type: application/pdf" \
+	--data-binary @"$FULLNAME")
 
 
 ######################################################################


### PR DESCRIPTION
The new versioning scheme is of the form `YYYY.MM-xx`, where `YYYY` and `MM` are the current year and month, respectively, and `xx` is a number which is incremented with every release starting from `01`. For development versions, the date then is calculated as `01/MM/YYYY`. During the release, this is automatically replaced with the actual date.

Merge #376 first.