### PR TITLE
Fix caching error

### DIFF
--- a/ToolsForHomalg/gap/CachingObjects.gi
+++ b/ToolsForHomalg/gap/CachingObjects.gi
@@ -481,8 +481,6 @@ InstallMethod( GetObject,
         
     fi;
     
-    cache!.value_list_position := cache!.value_list_position - 1;
-    
     CACHINGOBJECT_MISS( cache );
     
     return [ ];
@@ -504,12 +502,6 @@ InstallMethod( GetObject,
         return [ list[ pos ] ];
         
     fi;
-    
-#     Remove( cache!.keys_value_list, key_pos );
-#     
-#     Remove( cache!.value, pos );
-    
-    cache!.value_list_position := cache!.value_list_position - 1;
     
     CACHINGOBJECT_MISS( cache );
     


### PR DESCRIPTION
This fixes an error with the following code:
```
LoadPackage( "FinSetsForCAP" );
M := FinSet( [ 1 ] );
id := IdentityMorphism( M );
eq := Equalizer( [ id ] );
eq := fail;
GASMAN( "collect" );
emb := EmbeddingOfEqualizer( [ id ] );
```
(you have to put the code in a file and execute it to see the error, in a REPL GAP seems to keep references to `eq`).

Explanation: the call to `Equalizer` adds `eq` to `FinSets!.caches.EqualizerOp` and increments `FinSets!.caches.EqualizerOp.value_list_position` to `2`. After the garbage collection, the value is lost. Then `EmbeddingOfEqualizer` triggers a cache lookup of `EqualizerOp` during the redirect function, which decreases `FinSets!.caches.EqualizerOp.value_list_position` by one. Since the value is not found in the cache, `Equalizer( [ id ] )` is computed (to subsequently call `EmbeddingOfEqualizerWithGivenEqualizer`). This triggers another cache lookup, which decreases `FinSets!.caches.EqualizerOp.value_list_position` by one again. Finally, the result of `Equalizer( [ id ] )` is added to the cache at position `FinSets!.caches.EqualizerOp.value_list_position` which fails as this position is now zero.

This PR disables decreasing `FinSets!.caches.EqualizerOp.value_list_position` by one if a cache miss occurs. I think decreasing the value made more sense when the two `Remove` lines above were not commented yet in the past, but still was wrong as the missing value might not necessarily be the last value in the cache.

I think the correct place to decrease `FinSets!.caches.EqualizerOp.value_list_position` would be `TOOLS_FOR_HOMALG_CACHE_CLEAN_UP`, but I do not want to touch that function to not break anything.