### PR TITLE
Use permalinks for PackageWWWHome

### DIFF
--- a/4ti2Interface/PackageInfo.g
+++ b/4ti2Interface/PackageInfo.g
@@ -45,7 +45,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/4ti2Interface",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/4ti2Interface",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/4ti2Interface/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/4ti2Interface/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/4ti2Interface-", ~.Version, "/4ti2Interface-", ~.Version ),

--- a/ExamplesForHomalg/PackageInfo.g
+++ b/ExamplesForHomalg/PackageInfo.g
@@ -67,7 +67,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/ExamplesForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/ExamplesForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/ExamplesForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/ExamplesForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/ExamplesForHomalg-", ~.Version, "/ExamplesForHomalg-", ~.Version ),

--- a/Gauss/PackageInfo.g
+++ b/Gauss/PackageInfo.g
@@ -67,7 +67,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/Gauss",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/Gauss",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/Gauss/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/Gauss/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/Gauss-", ~.Version, "/Gauss-", ~.Version ),

--- a/GaussForHomalg/PackageInfo.g
+++ b/GaussForHomalg/PackageInfo.g
@@ -51,7 +51,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/GaussForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/GaussForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/GaussForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/GaussForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/GaussForHomalg-", ~.Version, "/GaussForHomalg-", ~.Version ),

--- a/GradedModules/PackageInfo.g
+++ b/GradedModules/PackageInfo.g
@@ -131,7 +131,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/GradedModules",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/GradedModules",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/GradedModules/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/GradedModules/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/GradedModules-", ~.Version, "/GradedModules-", ~.Version ),

--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -136,7 +136,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/GradedRingForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/GradedRingForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/GradedRingForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/GradedRingForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/GradedRingForHomalg-", ~.Version, "/GradedRingForHomalg-", ~.Version ),

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -132,7 +132,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/HomalgToCAS",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/HomalgToCAS",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/HomalgToCAS/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/HomalgToCAS/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/HomalgToCAS-", ~.Version, "/HomalgToCAS-", ~.Version ),

--- a/IO_ForHomalg/PackageInfo.g
+++ b/IO_ForHomalg/PackageInfo.g
@@ -101,7 +101,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/IO_ForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/IO_ForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/IO_ForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/IO_ForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/IO_ForHomalg-", ~.Version, "/IO_ForHomalg-", ~.Version ),

--- a/LocalizeRingForHomalg/PackageInfo.g
+++ b/LocalizeRingForHomalg/PackageInfo.g
@@ -80,7 +80,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/LocalizeRingForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/LocalizeRingForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/LocalizeRingForHomalg-", ~.Version, "/LocalizeRingForHomalg-", ~.Version ),

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -104,7 +104,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/MatricesForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/MatricesForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/MatricesForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/MatricesForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/MatricesForHomalg-", ~.Version, "/MatricesForHomalg-", ~.Version ),

--- a/Modules/PackageInfo.g
+++ b/Modules/PackageInfo.g
@@ -131,7 +131,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/Modules",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/Modules",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/Modules/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/Modules/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/Modules-", ~.Version, "/Modules-", ~.Version ),

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -192,7 +192,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/RingsForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/RingsForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/RingsForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/RingsForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/RingsForHomalg-", ~.Version, "/RingsForHomalg-", ~.Version ),

--- a/SCO/PackageInfo.g
+++ b/SCO/PackageInfo.g
@@ -51,7 +51,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/SCO",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/SCO",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/SCO/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/SCO/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/SCO-", ~.Version, "/SCO-", ~.Version ),

--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -80,7 +80,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/ToolsForHomalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/ToolsForHomalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/ToolsForHomalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/ToolsForHomalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/ToolsForHomalg-", ~.Version, "/ToolsForHomalg-", ~.Version ),

--- a/homalg/PackageInfo.g
+++ b/homalg/PackageInfo.g
@@ -77,7 +77,7 @@ SourceRepository := rec(
     URL := "https://github.com/homalg-project/homalg_project",
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := "https://homalg-project.github.io/homalg_project/homalg",
+PackageWWWHome  := "https://homalg-project.github.io/pkg/homalg",
 PackageInfoURL  := "https://homalg-project.github.io/homalg_project/homalg/PackageInfo.g",
 README_URL      := "https://homalg-project.github.io/homalg_project/homalg/README.md",
 ArchiveURL      := Concatenation( "https://github.com/homalg-project/homalg_project/releases/download/homalg-", ~.Version, "/homalg-", ~.Version ),


### PR DESCRIPTION
A question @alex-konovalov: Do your GAP release scripts fetch the content of `PackageWWWHome` (and thus would possible be broken by this change, as the new URLs are redirects), or do they only care about `PackageInfoURL`, `README_URL`, etc.?