### PR TITLE
Use liftstd

### DIFF
--- a/RingsForHomalg/gap/Singular.gi
+++ b/RingsForHomalg/gap/Singular.gi
@@ -149,6 +149,8 @@ end );
 InstallValue( SingularMacros,
         rec(
             
+    use_liftstd := "int use_liftstd = 1;",
+    
     IsMemberOfList := "\n\
 proc IsMemberOfList (int i, list l)\n\
 {\n\
@@ -597,11 +599,19 @@ proc IndicatorMatrixOfNonZeroEntries(matrix M)\n\
 ##    <Description>
 ##    
 ##      <Listing Type="Code"><![CDATA[
-    BasisOfRowModule := "\n\
-proc BasisOfRowModule (matrix M)\n\
-{\n\
-  return(std(M));\n\
-}\n\n",
+    BasisOfRowModule := """
+proc BasisOfRowModule (matrix M)
+{
+  if (use_liftstd) {
+    matrix T;
+    return(matrix(liftstd(module(M),T,"std",0)));
+  }
+  else {
+    return(std(M));
+  }
+}
+
+""",
 ##  ]]></Listing>
 ##    </Description>
 ##  </ManSection>
@@ -636,18 +646,30 @@ proc PartiallyReducedBasisOfColumnModule (matrix M)\n\
   return(Involution(PartiallyReducedBasisOfRowModule(Involution(M))));\n\
 }\n\n",
     
-#    ## according to the documentation B=M*T in the commutative case, but it somehow does not work :(
-#    ## and for plural to work one would need to define B=transpose(transpose(T)*transpose(M)), which is expensive!!
-#    BasisOfRowsCoeff := "\n\
-#proc BasisOfRowsCoeff (matrix M)\n\
-#{\n\
-#  matrix T;\n\
-#  matrix B = matrix(liftstd(M,T));\n\
-#  list l = transpose(transpose(T)*transpose(M)),T;\n\
-#  return(l)\n\
-#}\n\n",
+    BasisOfRowsCoeffViaLift := """
+proc BasisOfRowsCoeffViaLift (matrix M)
+{
+  matrix B = BasisOfRowModule(M);
+  option(noredSB);
+  matrix T = lift(M,B);
+  option(redSB);
+  list l = B,T;
+  return(l);
+}
 
-#never use stdlift, also because it might differ from std!!!
+""",
+
+    BasisOfRowsCoeffInteresting := """
+proc BasisOfRowsCoeffInteresting (matrix M, int limit)
+{
+  matrix T;
+  matrix B = matrix(liftstd(module(M),T,limit));
+  list l = B,T;
+  return(l);
+}
+
+""",
+
 ##  <#GAPDoc Label="BasisOfRowsCoeff:SingularMacro">
 ##  <ManSection>
 ##    <Func Arg="M, T" Name="BasisOfRowsCoeff" Label="Singular macro"/>
@@ -658,15 +680,41 @@ proc PartiallyReducedBasisOfColumnModule (matrix M)\n\
     BasisOfRowsCoeff := """
 proc BasisOfRowsCoeff (matrix M)
 {
-  matrix B = BasisOfRowModule(M);
-  option(noredSB);
-  matrix T = lift(M,B);
-  option(redSB);
+  return(RelativeBasisOfRowsCoeff(M,ncols(M)));
+}
+
+""",
+
+    RelativeBasisOfRowsCoeff := """
+proc RelativeBasisOfRowsCoeff (matrix M,int limit)
+{
+  if (use_liftstd) {
+    matrix T1;
+    module B1 = liftstd(module(M),T1,"std",limit);
+    // make sure we get the same output as when applying std
+    module B2 = std(B1);
+    matrix T2 = lift(B1,B2);
+    
+    // TODO: test this
+    matrix B = matrix(B2);
+    if (hasCommutativeVars(basering)) {
+      matrix T = T1 * T2;
+    }
+    else {
+      matrix T = transpose(transpose(T2) * transpose(T1));
+    }
+  }
+  else {
+    matrix B = BasisOfRowModule(M);
+    option(noredSB);
+    matrix T = lift(M,B);
+    option(redSB);
+  }
   list l = B,T;
   return(l);
 }
 
- """,
+""",
 ##  ]]></Listing>
 ##    </Description>
 ##  </ManSection>
@@ -790,11 +838,24 @@ proc SyzForHomalg (matrix M)\n\
 ##    <Description>
 ##    
 ##      <Listing Type="Code"><![CDATA[
-    SyzygiesGeneratorsOfRows := "\n\
-proc SyzygiesGeneratorsOfRows (matrix M)\n\
-{\n\
-  return(SyzForHomalg(M));\n\
-}\n\n",
+    SyzygiesGeneratorsOfRows := """
+proc SyzygiesGeneratorsOfRows (matrix M)
+{
+  if (use_liftstd) {
+    matrix T;
+    module S;
+    // TODO: needed?
+    option("redTailSyz");
+    liftstd(module(M),T,S,"std");
+    option("noredTailSyz");
+    return(matrix(S));
+  }
+  else {
+    return(SyzForHomalg(M));
+  }
+}
+
+""",
 ##  ]]></Listing>
 ##    </Description>
 ##  </ManSection>
@@ -824,11 +885,25 @@ proc SyzygiesGeneratorsOfColumns (matrix M)\n\
 ##    <Description>
 ##    
 ##      <Listing Type="Code"><![CDATA[
-    RelativeSyzygiesGeneratorsOfRows := "\n\
-proc RelativeSyzygiesGeneratorsOfRows (matrix M1, matrix M2)\n\
-{\n\
-  return(BasisOfRowModule(modulo(M1, M2)));\n\
-}\n\n",
+    RelativeSyzygiesGeneratorsOfRows := """
+proc RelativeSyzygiesGeneratorsOfRows (matrix M1, matrix M2)
+{
+  if (use_liftstd) {
+    matrix T;
+    module S;
+    // TODO: needed?
+    option("redTailSyz");
+    liftstd(module(concat(M1,M2)),T,S,"std",nrcols(M1));
+    option("noredTailSyz");
+    // TODO: additional BasisOfRowModule?
+    return(submat(matrix(S),1..ncols(M1),1..ncols(S)));
+  }
+  else {
+    return(BasisOfRowModule(modulo(M1, M2)));
+  }
+}
+
+""",
 ##  ]]></Listing>
 ##    </Description>
 ##  </ManSection>

--- a/RingsForHomalg/gap/SingularBasic.gi
+++ b/RingsForHomalg/gap/SingularBasic.gi
@@ -114,6 +114,32 @@ BasisOfRowsCoeff :=
     return N;
     
   end,
+
+RelativeBasisOfRowsCoeff :=
+  function( M, T, limit )
+    local v, N;
+    
+    v := homalgStream( HomalgRing( M ) )!.variable_name;
+    
+    N := HomalgVoidMatrix(
+      "unknown_number_of_rows",
+      NrColumns( M ),
+      HomalgRing( M )
+    );
+    
+    homalgSendBlocking(
+      [
+        "list ", v, "l=RelativeBasisOfRowsCoeff(", M, ", ", limit, "); ",
+        "matrix ", N, " = ", v, "l[1]; ",
+        "matrix ", T, " = ", v, "l[2]"
+      ],
+      "need_command",
+      "BasisCoeff"
+    );
+    
+    return N;
+    
+  end,
 ##  ]]></Listing>
 ##    </Description>
 ##  </ManSection>


### PR DESCRIPTION
This PR is based on the following Singular commit: https://github.com/zickgraf/Singular/commit/7a65a82fafdafc2bd72311ea4f27f9fabc1af5d3. I want to gather feedback before creating a PR for Singular.

The Singular commit allows to only compute a certain number of rows (given by the integer `limit`) of the transformation or syzygy matrix in `liftstd`. In combination with some recent fixes (e.g. https://github.com/Singular/Singular/commit/bc42722a945eb169cb68ca123321f864dc662fa1 and https://github.com/Singular/Singular/commit/ff4cbacc83944accd7caea5f872dc17187736644) this allows us to use `liftstd` for the following operations:
* `BasisOfRows`: special case `limit = 0`, i.e. `liftstd(M,T,0)`
* `SyzygiesOfRows`: `liftstd(M,T,S)`
* `RelativeSyzygiesOfRows`: `liftstd(concat(M,N),T,S,ncols(M))`
* `BasisOfRowsCoeff`: `liftstd(M,T)`

In the first three cases the runtime is nearly the same (some minimal overhead exists), in the last case the new implementation is much faster as it uses all the optimizations made for `liftstd` (in one example of mine the runtime improved by a factor of 3). And for syzygies we can maybe actually make use of the basis of rows and transformation matrix which we now automatically get without any additional computation.

Additionally, we can create a new operation:
* `RelativeBasisOfRowsCoeff`: `liftstd(M,T,limit)`

which can be used to write a relative version of `DecideZeroRowsEffectively` which can in turn be used for making `RelativeRightDivide` faster (this at least reduces the impact of the problem described in https://github.com/Singular/Singular/pull/1038).

Once all of this is part of a Singular release, I would enable this conditionally based on the version of Singular (see the variable `use_liftstd` which is currently hardcoded to `1`).

As mentioned above, I would like to gather some feedback before creating a PR for Singular:
* Are there other operations which would maybe fit in this scheme?
* There is a warning in the code regarding `liftstd`: `for plural to work one would need to define B=transpose(transpose(T)*transpose(M)), which is expensive!!`. I think this equality is what Singular actually computes, and this is not a problem because of the special definition of `RP!.Compose` for non-commutative rings, correct?
* There is a warning in the code `but it somehow does not work :(`. I think this describes an issue fixed by https://github.com/Singular/Singular/commit/bc42722a945eb169cb68ca123321f864dc662fa1.
* The output of `liftstd` might differ from `std` by some integral scalars as Singular eliminates denominators in the transformation matrix. I avoid this problem by forcing the result to be compatible with `std` by computing another lift. ~This lift should be cheap, but for non-commutative rings this involves transposing three times. And maybe it even makes sense to keep the transformation matrix free of denominators? So maybe this is not the best approach.~ This is more expensive than I thought (even in the commutative case), so I would like to explore alternatives: I could try to prevent Singular from clearing denominators in the transformation matrix, but I think this would get ugly. So I suggest we keep the integers, and introduce an operation `BasisOfRowsCoeffWithGivenBasisOfRows` which computes the additional lift only in the case where we have computed a basis of rows before.
* We can greatly speed up the computation of syzygies by not setting `redTailSyz`. When using `syz`, syzygies are automatically reduced modulo other syzygies during the computation. When using `liftstd`, this behaviour is disabled by default and can be enabled using `redTailSyz`. Keeping this disabled gives a great performance boost but can of course make the computed syzygies "less nice". Is there any syzygy-heavy test I could run to see if this makes a difference?
* `RelativeSyzygiesGeneratorsOfRows` actually computes a basis of rows of syzygies. I have chosen not to compute a basis of rows in the new code and see if it makes any difference in the CI.