### PR TITLE
Revert "fixed exchange of attributes for graded ring elements"

### DIFF
--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "GradedRingForHomalg",
 Subtitle := "Endow Commutative Rings with an Abelian Grading",
 
 Version := Maximum( [
-  "2021.02-02", ## Mohamed's version
+  "2021.02-01", ## Mohamed's version
 ## this line prevents merge conflicts
   "2020.02-05", ## Markus' version
 ## this line prevents merge conflicts

--- a/GradedRingForHomalg/gap/LIGrRNG.gi
+++ b/GradedRingForHomalg/gap/LIGrRNG.gi
@@ -148,7 +148,7 @@ InstallGlobalFunction( HelperToInstallMethodsForGradedRingElementsAttributes,
         
         InstallMethod( GRADEDRING_prop,
                 "for homalg graded rings",
-                [ IsHomalgGradedRingRep and Tester( GRADEDRING_prop ) ],
+                [ IsHomalgGradedRingRep ],
                 
           function( S )
             local indets;

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "RingsForHomalg",
 Subtitle := "Dictionaries of external rings",
 
 Version := Maximum( [
-  "2020.11-01", ## Mohamed's version
+  "2021.02-02", ## Mohamed's version
 ## this line prevents merge conflicts
   "2020.02-05", ## Markus L-H's version
 ## this line prevents merge conflicts


### PR DESCRIPTION
This reverts commit dc56d8ef91e83aec47b4c82eae81faa567de85d8.

Fixes #396