### PR TITLE
Reenable ci-test_RingsForHomalg

### DIFF
--- a/makefile
+++ b/makefile
@@ -113,12 +113,10 @@ ci-test_MatricesForHomalg:
 
 ci-test_RingsForHomalg:
 ifneq ($(SINGULAR_PATH),)
-ifneq ($(SAGE_PATH),)
 ifneq ($(M2_PATH),)
 ifneq ($(MAGMA_PATH),)
 ifneq ($(MAPLE_PATH),)
 	$(MAKE) -C RingsForHomalg ci-test
-endif
 endif
 endif
 endif


### PR DESCRIPTION
This should probably have been part of 77639921c49a4169bd06b92f56b9be7abf94b63c.