### PR TITLE
improve ViewString for homalg modules

### DIFF
--- a/Modules/PackageInfo.g
+++ b/Modules/PackageInfo.g
@@ -5,7 +5,7 @@ PackageName := "Modules",
 Subtitle := "A homalg based package for the Abelian category of finitely presented modules over computable rings",
 
 Version := Maximum( [
-  "2021.03-03", ## Mohamed's version
+  "2021.03-04", ## Mohamed's version
 ## this line prevents merge conflicts
   "2020.02-05", ## Markus' version
 ## this line prevents merge conflicts

--- a/Modules/gap/HomalgModule.gi
+++ b/Modules/gap/HomalgModule.gi
@@ -2681,7 +2681,7 @@ InstallMethod( ViewString,
         return ViewString( o );
     fi;
     
-    is_submodule := IsFinitelyPresentedSubmoduleRep( o );
+    is_submodule := IsStaticFinitelyPresentedSubobjectRep( o );
     
     if is_submodule and HasEmbeddingInSuperObject( o ) then
         M := UnderlyingObject( o );


### PR DESCRIPTION
replace IsFinitelyPresentedSubmoduleRep -> IsStaticFinitelyPresentedSubobjectRep
to be able to handle homalg managed subobjects in CAP categories