### PR TITLE
Install LaTeXStringOp for elements of graded rings

### DIFF
--- a/GradedRingForHomalg/gap/Tools.gi
+++ b/GradedRingForHomalg/gap/Tools.gi
@@ -756,6 +756,14 @@ InstallMethod( Coefficients,
 end );
 
 ##
+InstallMethod( LaTeXStringOp,
+        "for homalg graded ring elements",
+        [ IsHomalgGradedRingElement ],
+        
+  r -> LaTeXStringOp( EvalRingElement( r ) )
+);
+
+##
 InstallMethod( ExponentsOfGeneratorsOfToricIdeal,
         "for a list",
         [ IsList ],


### PR DESCRIPTION
Without this PR `LaTeXStringOp(e)` would fall back to `String(e)`.