### PR TITLE
Remove Autoload from PackageInfo.g files

### DIFF
--- a/4ti2Interface/PackageInfo.g
+++ b/4ti2Interface/PackageInfo.g
@@ -62,7 +62,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "An interface to 4ti2.",
-  Autoload  := false
 ),
 
 
@@ -99,7 +98,6 @@ AvailabilityTest := function()
     
 end,
 
-Autoload := false,
 
 
 Keywords := [  ]

--- a/ExamplesForHomalg/PackageInfo.g
+++ b/ExamplesForHomalg/PackageInfo.g
@@ -85,7 +85,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Examples for the GAP Package homalg",
-  Autoload  := false
 ),
 
 
@@ -108,7 +107,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := [ "examples", "homalg" ]

--- a/Gauss/PackageInfo.g
+++ b/Gauss/PackageInfo.g
@@ -84,7 +84,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Extended Gauss functionality for GAP",
-  Autoload  := false
 ),
 
 Dependencies := rec(
@@ -104,7 +103,6 @@ AvailabilityTest := function()
   return true;
 end,
 
-Autoload := false,
 
 
 Keywords := ["Gauss", "RREF", "sparse" ]

--- a/GaussForHomalg/PackageInfo.g
+++ b/GaussForHomalg/PackageInfo.g
@@ -69,7 +69,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Gauss functionality for the homalg project",
-  Autoload  := false
 ),
 
 
@@ -88,7 +87,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := ["GaussForHomalg", "homalg", "Gauss" ]

--- a/GradedModules/PackageInfo.g
+++ b/GradedModules/PackageInfo.g
@@ -148,7 +148,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A homalg based package for the Abelian category of finitely presented graded modules over computable graded rings",
-  Autoload  := false
 ),
 
 
@@ -172,7 +171,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := ["modules", "graded modules", "graduation", "multi-graded modules", "Tate resolution"]

--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -161,7 +161,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Endow Commutative Rings with an Abelian Grading",
-  Autoload  := false
 ),
 
 
@@ -185,7 +184,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := [ "homological algebra", "graded ring" ]

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -149,7 +149,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A window to the outer world",
-  Autoload  := false
 ),
 
 
@@ -169,7 +168,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := [ "homalgExternalObject", "CreateHomalgExternalRing", "HomalgExternalRingElement", "IsHomalgExternalMatrixRep", "LaunchCAS", "TerminateCAS", "homalgSendBlocking" ]

--- a/IO_ForHomalg/PackageInfo.g
+++ b/IO_ForHomalg/PackageInfo.g
@@ -119,7 +119,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "IO capabilities for the homalg project",
-  Autoload  := false
 ),
 
 
@@ -135,7 +134,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := [ "IO", "streams" ]

--- a/LocalizeRingForHomalg/PackageInfo.g
+++ b/LocalizeRingForHomalg/PackageInfo.g
@@ -97,7 +97,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A Package for Localization of Polynomial Rings",
-  Autoload  := false
 ),
 
 
@@ -119,7 +118,6 @@ AvailabilityTest := function()
   end,
 
 
-Autoload := false,
 
 
 Keywords := [ "homological algebra", "local ring", "submodule membership problem", "syzygies", "Mora" ]

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -121,7 +121,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Lazy evaluated matrices with clever operations for the homalg project",
-  Autoload  := false
 ),
 
 
@@ -140,7 +139,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := [ "rings", "ring elements", "matrices", "lazy evaluated matrices", "clever operations for matrices", "submodule membership problem", "syzygies" ]

--- a/Modules/PackageInfo.g
+++ b/Modules/PackageInfo.g
@@ -148,7 +148,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A homalg based package for the Abelian category of finitely presented modules over computable rings",
-  Autoload  := false
 ),
 
 
@@ -169,7 +168,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := ["modules", "module homomorphisms", "functor", "ext", "tor"]

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -211,7 +211,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Dictionaries of external rings for the homalg project",
-  Autoload  := false
 ),
 
 
@@ -232,7 +231,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := [ "rings", "ideal membership problem", "syzygies", "homalgTable" ]

--- a/SCO/PackageInfo.g
+++ b/SCO/PackageInfo.g
@@ -68,7 +68,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "SCO - Simplicial Cohomology of Orbifolds",
-  Autoload  := true
 ),
 
 
@@ -85,7 +84,6 @@ AvailabilityTest := function()
   end,
 
 
-Autoload := false,
 
 
 Keywords := ["homology", "cohomology", "orbifold", "groupoid", "simplicial", "triangulation" ]

--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -101,7 +101,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "Provides special methods and knowledge propagation tools",
-  Autoload  := false
 ),
 
 
@@ -122,7 +121,6 @@ AvailabilityTest := function()
   end,
 
 
-Autoload := false,
 
 
 Keywords := [  ]

--- a/homalg/PackageInfo.g
+++ b/homalg/PackageInfo.g
@@ -94,7 +94,6 @@ PackageDoc := rec(
   PDFFile   := "doc/manual.pdf",
   SixFile   := "doc/manual.six",
   LongTitle := "A homological algebra meta-package for computable Abelian categories",
-  Autoload  := false
 ),
 
 
@@ -112,7 +111,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-Autoload := false,
 
 
 Keywords := ["homological", "filtration", "bicomplex", "spectral sequence", "Grothendieck", "functor"]


### PR DESCRIPTION
Both of its uses (to control loading of the package, and of its
manuals) have been removed many years ago.