### PR TITLE
Bump version of ToolsForHomalg for new release

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ Version := Maximum( [
 ## this line prevents merge conflicts
   "2018.05-22", ## Sebas' version
 ## this line prevents merge conflicts
-  "2021.03-01", ## Fabian's version
+  "2021.05-01", ## Fabian's version
 ## this line prevents merge conflicts
   "2020.09-02", ## Kamal's version
 ## this line prevents merge conflicts


### PR DESCRIPTION
I have bumped the version in 2a1069af3b854920a91875013654b15ae8123fa1 but
master already had a newer version, so no release was made.

Partially fixes https://github.com/homalg-project/CAP_project/issues/669