### PR TITLE
Add lazy CoercedMatrix

### DIFF
--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -7,7 +7,7 @@ Subtitle := "Matrices for the homalg project",
 Version := Maximum( [
   "2021.06-03", ## Mohamed's version
 ## this line prevents merge conflicts
-  "2021.04-04", ## Fabian's version
+  "2021.07-01", ## Fabian's version
 ## this line prevents merge conflicts
   "2020.02-05", ## Markus' version
 ## this line prevents merge conflicts

--- a/MatricesForHomalg/doc/Logic.xml
+++ b/MatricesForHomalg/doc/Logic.xml
@@ -45,6 +45,7 @@ the attribute <C>Eval</C>.
 <#Include Label="Eval:HasEvalRightInverse">
 <#Include Label="Eval:HasEvalInvolution">
 <#Include Label="Eval:HasEvalTransposedMatrix">
+<#Include Label="Eval:HasEvalCoercedMatrix">
 <#Include Label="Eval:HasEvalCertainRows">
 <#Include Label="Eval:HasEvalCertainColumns">
 <#Include Label="Eval:HasEvalUnionOfRows">

--- a/MatricesForHomalg/doc/Matrices.xml
+++ b/MatricesForHomalg/doc/Matrices.xml
@@ -31,6 +31,7 @@
 <#Include Label="HomalgMatrix">
 <#Include Label="HomalgDiagonalMatrix">
 <#Include Label="\*:MatrixBaseChange">
+<#Include Label="CoercedMatrix">
 
 </Section>
 

--- a/MatricesForHomalg/examples/CoercedMatrix.g
+++ b/MatricesForHomalg/examples/CoercedMatrix.g
@@ -1,0 +1,13 @@
+LoadPackage( "MatricesForHomalg" );
+LoadPackage( "GaussForHomalg" );
+
+ZZ := HomalgRingOfIntegers( );
+QQ := HomalgFieldOfRationals( );
+
+M := HomalgMatrix( [ 1, 2, 3, 4 ], 2, 2, ZZ );
+N := CoercedMatrix( QQ, M );
+P := CoercedMatrix( ZZ, QQ, M );
+Assert( 0, N = P );
+Assert( 0, NrRows( N ) = NrRows( M ) and NrCols( N ) = NrCols( M ) );
+Assert( 0, IsIdenticalObj( HomalgRing( N ), QQ ) );
+Eval( N );

--- a/MatricesForHomalg/gap/HomalgMatrix.gd
+++ b/MatricesForHomalg/gap/HomalgMatrix.gd
@@ -460,6 +460,9 @@ DeclareAttribute( "EvalTransposedMatrix",
 DeclareAttribute( "ItsTransposedMatrix",
         IsHomalgMatrix );
 
+DeclareAttribute( "EvalCoercedMatrix",
+        IsHomalgMatrix );
+
 DeclareAttribute( "EvalCertainRows",
         IsHomalgMatrix );
 
@@ -1117,6 +1120,13 @@ DeclareOperation( "Involution",
 
 DeclareOperation( "TransposedMatrix",
         [ IsHomalgMatrix ] );
+
+# convenience
+DeclareOperation( "CoercedMatrix",
+        [ IsHomalgRing, IsHomalgMatrix ] );
+
+DeclareOperation( "CoercedMatrix",
+        [ IsHomalgRing, IsHomalgRing, IsHomalgMatrix ] );
 
 DeclareOperation( "CertainRows",
         [ IsHomalgMatrix, IsList ] );

--- a/MatricesForHomalg/gap/HomalgMatrix.gi
+++ b/MatricesForHomalg/gap/HomalgMatrix.gi
@@ -3470,6 +3470,53 @@ InstallMethod( \*,
 end );
 
 ##
+# convenience
+InstallMethod( CoercedMatrix,
+        "for a homalg ring and a homalg matrix",
+        [ IsHomalgRing, IsHomalgMatrix ],
+
+  function( new_ring, M )
+    
+    return CoercedMatrix( HomalgRing( M ), new_ring, M );
+    
+end );
+
+##  <#GAPDoc Label="CoercedMatrix">
+##  <ManSection>
+##    <Oper Arg="ring_from, ring_to, mat" Name="CoercedMatrix" Label="copy a matrix over a different ring"/>
+##    <Oper Arg="ring_to, mat" Name="CoercedMatrix" Label="copy a matrix over a different ring (convenience)"/>
+##    <Returns>a &homalg; matrix</Returns>
+##    <Description>
+##      A copy of the &homalg; matrix <A>mat</A> with &homalg; ring <A>ring_from</A> in the &homalg; ring <A>ring_to</A>.<P/>
+##      (for the installed standard method see <Ref Meth="Eval" Label="for matrices created with CoercedMatrix"/>)
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+##
+InstallMethod( CoercedMatrix,
+        "for two homalg rings and a homalg matrix",
+        [ IsHomalgRing, IsHomalgRing, IsHomalgMatrix ],
+
+  function( old_ring, new_ring, M )
+    local C;
+    
+    if not IsIdenticalObj( old_ring, HomalgRing( M ) ) then
+        
+        Error( "the matrix <M> must be a matrix over the ring <old_ring>" );
+        
+    fi;
+    
+    C := HomalgMatrixWithAttributes( [
+                 EvalCoercedMatrix, M
+                 ], new_ring );
+    
+    BlindlyCopyMatrixProperties( M, C );
+    
+    return C;
+    
+end );
+
+##
 InstallGlobalFunction( ListToListList,
   function( L, r, c )
     

--- a/MatricesForHomalg/gap/Tools.gi
+++ b/MatricesForHomalg/gap/Tools.gi
@@ -518,6 +518,39 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 
+##  <#GAPDoc Label="Eval:HasEvalCoercedMatrix">
+##  <ManSection>
+##    <Meth Arg="C" Name="Eval" Label="for matrices created with CoercedMatrix"/>
+##    <Returns>the <C>Eval</C> value of a &homalg; matrix <A>C</A></Returns>
+##    <Description>
+##      In case the matrix was created using
+##      <Ref Meth="CoercedMatrix" Label="copy a matrix over a different ring"/>
+##      then the filter <C>HasEvalCoercedMatrix</C> for <A>C</A> is set to true and the <C>Eval</C> value
+##      of a copy of <C>EvalCoercedMatrix(</C><A>C</A><C>)</C> in <C>HomalgRing(</C><A>C</A><C>)</C>
+##      will be used to set the attribute <C>Eval</C>.
+##    <Listing Type="Code"><![CDATA[
+InstallMethod( Eval,
+        "for homalg matrices (HasEvalCoercedMatrix)",
+        [ IsHomalgMatrix and HasEvalCoercedMatrix ],
+        
+  function( C )
+    local R, RP, m;
+    
+    R := HomalgRing( C );
+    
+    RP := homalgTable( R );
+    
+    m := EvalCoercedMatrix( C );
+    
+    # delegate to the non-lazy coercening
+    return Eval( R * m );
+    
+end );
+##  ]]></Listing>
+##    </Description>
+##  </ManSection>
+##  <#/GAPDoc>
+
 ##  <#GAPDoc Label="Eval:HasEvalCertainRows">
 ##  <ManSection>
 ##    <Meth Arg="C" Name="Eval" Label="for matrices created with CertainRows"/>


### PR DESCRIPTION
Also see #327.

Now that `UnionOfRows` and `UnionOfColumns` get the ring as the first argument, I need more type information when coercing matrices. In particular, it is handy to have the source ring readily available. Thus, I have revived #327 with a three argument version of `CoercedMatrix`, where the first argument is the source ring. Of course, there is a convenience method where the source ring is simply obtained from the matrix.