### PR TITLE
Turn SimplifyHomalgMatrix* into attributes

### DIFF
--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -4,27 +4,7 @@ PackageName := "MatricesForHomalg",
 
 Subtitle := "Matrices for the homalg project",
 
-Version := Maximum( [
-  "2021.06-03", ## Mohamed's version
-## this line prevents merge conflicts
-  "2021.07-01", ## Fabian's version
-## this line prevents merge conflicts
-  "2020.02-05", ## Markus' version
-## this line prevents merge conflicts
-  "2019.09-01", ## Max' version
-## this line prevents merge conflicts
-  "2019.12-03", ## Sebas' version
-## this line prevents merge conflicts
-  "2017.07-01", ## Vinay's version
-## this line prevents merge conflicts
-  "2013.08-26", ## Martin's version
-## this line prevents merge conflicts
-  "2019.06-04", ## Florian's version
-## this line prevents merge conflicts
-  "2020.09-06", ## Sepp's version
-## this line prevents merge conflicts
-  "2020.10-04", ## Kamal's version
-] ),
+Version := "2021.08-01",
 
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 

--- a/MatricesForHomalg/gap/Basic.gd
+++ b/MatricesForHomalg/gap/Basic.gd
@@ -116,8 +116,13 @@ DeclareGlobalFunction( "BestBasis" );
 
 DeclareGlobalFunction( "SimplerEquivalentMatrix" );
 
-DeclareGlobalFunction( "SimplifyHomalgMatrixByLeftAndRightMultiplicationWithInvertibleMatrices" );
+# attributes:
 
-DeclareGlobalFunction( "SimplifyHomalgMatrixByLeftMultiplicationWithInvertibleMatrix" );
+DeclareAttribute( "SimplifyHomalgMatrixByLeftAndRightMultiplicationWithInvertibleMatrices",
+        IsHomalgMatrix );
 
-DeclareGlobalFunction( "SimplifyHomalgMatrixByRightMultiplicationWithInvertibleMatrix" );
+DeclareAttribute( "SimplifyHomalgMatrixByLeftMultiplicationWithInvertibleMatrix",
+        IsHomalgMatrix );
+
+DeclareAttribute( "SimplifyHomalgMatrixByRightMultiplicationWithInvertibleMatrix",
+        IsHomalgMatrix );

--- a/MatricesForHomalg/gap/Basic.gi
+++ b/MatricesForHomalg/gap/Basic.gi
@@ -1396,7 +1396,10 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-InstallGlobalFunction( SimplifyHomalgMatrixByLeftAndRightMultiplicationWithInvertibleMatrices,
+InstallMethod( SimplifyHomalgMatrixByLeftAndRightMultiplicationWithInvertibleMatrices,
+        "for homalg matrices",
+        [ IsHomalgMatrix ],
+        
     function( M )
         local ring, U, V, UI, VI, S;
         
@@ -1429,7 +1432,10 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-InstallGlobalFunction( SimplifyHomalgMatrixByLeftMultiplicationWithInvertibleMatrix,
+InstallMethod( SimplifyHomalgMatrixByLeftMultiplicationWithInvertibleMatrix,
+        "for homalg matrices",
+        [ IsHomalgMatrix ],
+        
     function( M )
         local R, RP, T, S;
         
@@ -1468,7 +1474,10 @@ end );
 ##  </ManSection>
 ##  <#/GAPDoc>
 ##
-InstallGlobalFunction( SimplifyHomalgMatrixByRightMultiplicationWithInvertibleMatrix,
+InstallMethod( SimplifyHomalgMatrixByRightMultiplicationWithInvertibleMatrix,
+        "for homalg matrices",
+        [ IsHomalgMatrix ],
+        
     function( M )
         local R, RP, T, S;
         


### PR DESCRIPTION
Those are used as attributes in CAP anyway, so turning them into attributes
on the homalg level does not change anything performance-wise, but makes
things easier for the compiler.

Note that I have simplified the `Version` in `PackageInfo.g` as discussed.