### PR TITLE
Make sure CrispCache does not remain in options stack after calling InstallMethodWithCrispCache

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -4,7 +4,7 @@ PackageName := "ToolsForHomalg",
 
 Subtitle := "Special methods and knowledge propagation tools",
 
-Version := "2021.12-02",
+Version := "2022.01-01",
 
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 

--- a/ToolsForHomalg/gap/CachingObjects.gi
+++ b/ToolsForHomalg/gap/CachingObjects.gi
@@ -698,9 +698,7 @@ InstallGlobalFunction( InstallMethodWithCrispCache,
                        
   function( arg )
     
-    PushOptions( rec( CrispCache := true ) );
-    
-    CallFuncList( InstallMethodWithCache, arg );
+    CallFuncList( InstallMethodWithCache, arg : CrispCache := true );
     
 end );
 


### PR DESCRIPTION
The previous behavior made all calls to `InstallMethodWithCache` after calling `InstallMethodWithCrispCache` at least once use crisp caching. This did not affect CAP operations because those are installed with their cache object explicitly.

Note: This fix might cause arbitrary performance changes if code benefits or suffers from the use of crisp caching.