### PR TITLE
ZERO -> ZeroSameMutability

### DIFF
--- a/Modules/gap/GrothendieckGroup.gi
+++ b/Modules/gap/GrothendieckGroup.gi
@@ -204,7 +204,7 @@ InstallMethod( ChernPolynomial,
 end );
 
 ##
-InstallMethod( ZERO,
+InstallMethod( ZeroSameMutability,
         "for an element of the Grothendieck group of a projective space",
         [ IsElementOfGrothendieckGroupOfProjectiveSpaceRep and HasAssociatedPolynomial ],
         


### PR DESCRIPTION
These are aliases of each other, but the former is the kernel name (and
may change), the latter is the officially documented name (or rather:
one of them...).

Future GAP versions may rename ZERO... Indeed I am working on a PR doing that.
