### PR TITLE
Sort macros by name

### DIFF
--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedRingForHomalg",
 Subtitle := "Endow Commutative Rings with an Abelian Grading",
-Version := "2022.06-01",
+Version := "2022.07-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -144,8 +144,8 @@ Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [
                    [ "MatricesForHomalg", ">= 2020.06.27" ],
-                   [ "HomalgToCAS", ">= 2020.06.27" ],
-                   [ "RingsForHomalg", ">= 2020.06.27" ],
+                   [ "HomalgToCAS", ">= 2022.07-01" ],
+                   [ "RingsForHomalg", ">= 2022.07-01" ],
                    [ "Modules", ">= 2018.02.04" ],
                    [ "homalg", ">=2011.08.16" ],
                    [ "GAPDoc", ">= 1.0" ] ],

--- a/GradedRingForHomalg/gap/Macaulay2Tools.gi
+++ b/GradedRingForHomalg/gap/Macaulay2Tools.gi
@@ -86,7 +86,7 @@ NonTrivialWeightedDegreePerColumnWithRowPosition = (M,weights,R) -> ( local n,p;
     LinearSyzygiesGeneratorsOfRows := "\n\
 LinearSyzygiesGeneratorsOfRows = M -> Involution(LinearSyzygiesGeneratorsOfColumns(Involution(M)));\n\n",
     
-    LinearSyzygiesGeneratorsOfColumns := "\n\
+    0_LinearSyzygiesGeneratorsOfColumns := "\n\
 LinearSyzygiesGeneratorsOfColumns = M -> (\n\
   local R,S;\n\
   R = ring M;\n\

--- a/GradedRingForHomalg/gap/SingularTools.gi
+++ b/GradedRingForHomalg/gap/SingularTools.gi
@@ -134,7 +134,7 @@ proc NonTrivialWeightedDegreePerColumnWithRowPosition (matrix M, weights)\n\
   return(m);\n\
 }\n\n",
     
-    LinSyzForHomalg := "\n\
+    ("#LinSyzForHomalg") := "\n\
 proc LinSyzForHomalg(matrix m)\n\
 {\n\
   def save=degBound;\n\

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -2,7 +2,7 @@ SetPackageInfo( rec(
 
 PackageName := "HomalgToCAS",
 Subtitle := "A window to the outer world",
-Version := "2022.03-01",
+Version := "2022.07-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/HomalgToCAS/gap/IO.gi
+++ b/HomalgToCAS/gap/IO.gi
@@ -206,7 +206,7 @@ InstallGlobalFunction( InitializeMacros,
         Error( "the second argument must be a record\n" );
     fi;
     
-    names := NamesOfComponents( macros );
+    names := SortedList( NamesOfComponents( macros ) );
     
     if IsBound( macros._order ) and
        IsList( macros._order ) and

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -2,7 +2,7 @@ SetPackageInfo( rec(
 
 PackageName := "RingsForHomalg",
 Subtitle := "Dictionaries of external rings",
-Version := "2022.04-01",
+Version := "2022.07-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -199,7 +199,7 @@ Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [
                    [ "MatricesForHomalg", ">= 2022.04-01" ],
-                   [ "HomalgToCAS", ">= 2021.10-01" ],
+                   [ "HomalgToCAS", ">= 2022.07-01" ],
                    [ "GaussForHomalg", ">= 2020.06.27" ],
                    [ "GAPDoc", ">= 1.0" ]
                    ],

--- a/RingsForHomalg/gap/Singular.gi
+++ b/RingsForHomalg/gap/Singular.gi
@@ -893,7 +893,7 @@ proc ReducedSyzygiesGeneratorsOfColumns (matrix M)\n\
 ##  </ManSection>
 ##  <#/GAPDoc>
     
-    superCommutative_ForHomalg := "\n\
+    ("#superCommutative_ForHomalg") := "\n\
 if ( defined(superCommutative) == 1 ) // the new name of the SCA constructor\n\
 { proc superCommutative_ForHomalg = superCommutative; }\n\
 else\n\


### PR DESCRIPTION
Relying on the order of NamesOfComponents is not safe. As a consequence, we
have to explicitly sort `superCommutative_ForHomalg` and `LinSyzForHomalg`
before `CheckLinExtSyz`.