### PR TITLE
Fix wrong attribute in BasisOfColumnsCoeff

### DIFF
--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "MatricesForHomalg",
 Subtitle := "Matrices for the homalg project",
-Version := "2022.08-03",
+Version := "2022.08-04",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MatricesForHomalg/gap/Service.gi
+++ b/MatricesForHomalg/gap/Service.gi
@@ -2607,7 +2607,7 @@ InstallMethod( BasisOfColumnsCoeff,		### defines: BasisOfColumnsCoeff (BasisCoef
         
         ResetFilterObj( T, IsVoidMatrix );
         
-        SetNrColumns( T, NrRows( M ) );
+        SetNrRows( T, NrColumns( M ) );
         
         ## check assertion
         Assert( 6, R!.asserts.BasisOfColumnsCoeff( B, M, T ) );	# B = M * T


### PR DESCRIPTION
Luckily, NrColumns was already set in all cases, so this did not produce
wrong results.