### PR TITLE
Ignore warnings about egrep being obsolescent coming from 4ti2

### DIFF
--- a/4ti2Interface/PackageInfo.g
+++ b/4ti2Interface/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "4ti2Interface",
 Subtitle := "A link to 4ti2",
-Version := "2022.08-03",
+Version := "2022.09-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/4ti2Interface/gap/4ti2Interface.gi
+++ b/4ti2Interface/gap/4ti2Interface.gi
@@ -206,6 +206,8 @@ InstallGlobalFunction( 4ti2Interface_groebner,
     
     err := Concatenation( IO_ReadLines( filestream.stderr ) );
     
+    err := ReplacedString( err, "egrep: warning: egrep is obsolescent; using grep -E\n", "" );
+    
     while IO_ReadLine( filestream.stdout ) <> "" do od;
     
     IO_Close( filestream.stdin );


### PR DESCRIPTION
Fixes #521

Note: This might not cover all occurrences of this warning. I only made the tests pass, nothing more.