### PR TITLE
Revert "Restore compatibility for older versions of CAP"

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
-Version := "2022.09-07",
+Version := "2022.09-08",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/gap/ToolsForHomalg.gi
+++ b/ToolsForHomalg/gap/ToolsForHomalg.gi
@@ -2589,8 +2589,6 @@ InstallGlobalFunction( "ReplacedStringViaRecord", function( string, record )
             
             string := ReplacedString( string, Concatenation( name, "..." ), JoinStringsWithSeparator( record.(name), ", " ) );
             
-            string := ReplacedString( string, name, JoinStringsWithSeparator( record.(name), ", " ) );
-            
         else
             
             Error( "the record's values must be strings or lists of strings" );


### PR DESCRIPTION
This reverts commit c46d85bf2cc0247737667a8271fd18b3fc101dc9.

https://github.com/gap-system/PackageDistro/pull/570 is merged, so we do not need backward compatibility anymore.