### PR TITLE
Speed up RandomMatrix drastically

### DIFF
--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "HomalgToCAS",
 Subtitle := "A window to the outer world",
-Version := "2022.09-01",
+Version := "2022.10-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/HomalgToCAS/gap/HomalgToCAS.gi
+++ b/HomalgToCAS/gap/HomalgToCAS.gi
@@ -166,6 +166,9 @@ InstallValue( HOMALG_IO,
                 ## random polynomial:
                 RandomPol                               := "rpl",
                 
+                ## random matrix:
+                RandomMat                               := "rma",
+                
                 ## numerator:
                 Numerator                               := "num",
                 

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "MatricesForHomalg",
 Subtitle := "Matrices for the homalg project",
-Version := "2022.09-01",
+Version := "2022.10-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MatricesForHomalg/gap/Tools.gi
+++ b/MatricesForHomalg/gap/Tools.gi
@@ -5093,9 +5093,17 @@ InstallMethod( RandomMatrix,
         [ IsInt, IsInt, IsHomalgRing ],
         
   function( r, c, R )
-    local RP;
+    local RP, params;
     
     RP := homalgTable( R );
+    
+    if IsBound(RP!.RandomMat) then
+        
+        params := RandomCombination( [ 0 .. 10 ], Random( [ 1 .. 11 ] ) );
+        
+        return HomalgMatrix( CallFuncList( RP!.RandomMat, Concatenation( [ R, r, c ], params ) ), r, c, R );
+        
+    fi;
     
     if not IsBound(RP!.RandomPol) then
         TryNextMethod( );

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "RingsForHomalg",
 Subtitle := "Dictionaries of external rings",
-Version := "2022.09-01",
+Version := "2022.10-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 
@@ -208,7 +208,7 @@ Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [
                    [ "MatricesForHomalg", ">= 2022.04-01" ],
-                   [ "HomalgToCAS", ">= 2022.07-01" ],
+                   [ "HomalgToCAS", ">= 2022.10-01" ],
                    [ "GaussForHomalg", ">= 2020.06.27" ],
                    [ "GAPDoc", ">= 1.0" ]
                    ],

--- a/RingsForHomalg/gap/SingularTools.gi
+++ b/RingsForHomalg/gap/SingularTools.gi
@@ -983,12 +983,28 @@ BindGlobal( "CommonHomalgTableForSingularTools",
                  end,
                
                RandomPol :=
-                 function( arg )
-                   local R;
+                 function( R, args... )
                    
-                   R := arg[1];
+                   return homalgSendBlocking( [ "sparsepoly(", args, ")" ], [ "def" ], R, "RandomPol" );
                    
-                   return homalgSendBlocking( [ "sparsepoly(", arg{[ 2 .. Length( arg ) ]}, ")" ], [ "def" ], R, "RandomPol" );
+                 end,
+               
+               RandomMat :=
+                 function( R, r, c, args... )
+                   local tmp;
+                   
+                   if Length( args ) >= 2 then
+                       
+                       # The 3rd and 4th argument of sparsematrix correspond to the 2nd and 1st argument of sparsepoly above, i.e. are swapped.
+                       # To keep the interface consistent, we swap the corresponding entries of args here.
+                       args := ShallowCopy( args );
+                       tmp := args[2];
+                       args[2] := args[1];
+                       args[1] := tmp;
+                       
+                   fi;
+                   
+                   return homalgSendBlocking( [ "sparsematrix(", Concatenation( [ c, r ], args ), ")" ], [ "def" ], R, "RandomMat" );
                    
                  end,
                


### PR DESCRIPTION
Currently, random matrices are created entry by entry by choosing random ring elements. Directly creating a random matrix in the CAS is much faster.