### PR TITLE
Gauss: #include gap_all.h instead of src/compiled.h

### DIFF
--- a/Gauss/src/gauss.c
+++ b/Gauss/src/gauss.c
@@ -4,25 +4,7 @@
 **
 */
 
-/* Try to use as much of the GNU C library as possible: */
-#define _GNU_SOURCE
-
-#include "src/compiled.h"          /* GAP headers                */
-
-/* The following seems to be necessary to run under modern gcc compilers
- * which have the ssp stack checking enabled. Hopefully this does not
- * hurt in future or other versions... */
-#if 0
-#ifdef __GNUC__
-#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1))
-extern void __stack_chk_fail();
-void __stack_chk_fail_local (void)
-{
-  __stack_chk_fail ();
-}
-#endif
-#endif
-#endif
+#include "gap_all.h" // GAP headers
 
 Obj FuncSYMMETRIC_DIFFERENCE_OF_ORDERED_SETS_OF_SMALL_INTEGERS( Obj self, Obj a, Obj b )
 {


### PR DESCRIPTION
This helps GAP packages in Linux distros.

Also apply some cleanup
