### PR TITLE
Install TopcomInterface for ci tests

### DIFF
--- a/ci_prepare
+++ b/ci_prepare
@@ -24,4 +24,8 @@ cd CddInterface
 ./install.sh $GAP_HOME
 cd ..
 
+cd ToricVarieties_project/TopcomInterface
+make install
+cd ../..
+
 cd homalg_project

--- a/makefile
+++ b/makefile
@@ -19,8 +19,7 @@ ci-prepare:
 
 ci-test_homalg_packages: ci-test_4ti2Interface ci-test_Gauss ci-test_ExamplesForHomalg ci-test_GaussForHomalg ci-test_GradedModules ci-test_HomalgToCAS ci-test_GradedRingForHomalg ci-test_IO_ForHomalg ci-test_LocalizeRingForHomalg ci-test_MatricesForHomalg ci-test_RingsForHomalg ci-test_SCO ci-test_Modules ci-test_homalg
 
-ci-test_additional_packages: ci-test_alexander ci-test_CAP_project ci-test_D-Modules ci-test_Sheaves ci-test_VirtualCAS
-# ci-test_ToricVarieties: https://github.com/homalg-project/ToricVarieties_project/issues/200
+ci-test_additional_packages: ci-test_alexander ci-test_CAP_project ci-test_D-Modules ci-test_Sheaves ci-test_ToricVarieties ci-test_VirtualCAS
 
 ci-test: ci-test_LoadSheaves ci-test_homalg_packages ci-test_additional_packages
 	cd .. && homalg_project/gather_performance_data.py


### PR DESCRIPTION
An attempt at building the `TopcomInterface` for the ci-tests of the `homalg_project,` so that a fixed version of `topcom` is being used (cf. https://github.com/homalg-project/ToricVarieties_project/issues/200). The idea is that the installer of the `TopcomInterface` downloads and builds the version inside the folder of the `TopcomInterface` package. Ideally, the package should then find and use this very version of `topcom` (rather than e.g. the system version).

Note that this could be easily extended to the entire `ToricVarieties_project` by executing `make install` in the root folder of the `ToricVarieties_project`. I have not done this here, as it requires more build time. If this is desirable and you want to execute all tests of the `ToricVarieties_project`, this is how it could be initiated.
