### PR TITLE
Turn IO into a suggested dependency of HomalgToCAS

### DIFF
--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -160,11 +160,12 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.11.1",
   NeededOtherPackages := [
-                [ "IO", ">= 2.3" ],
                 [ "MatricesForHomalg", ">= 2019.09.01" ],
                 [ "GAPDoc", ">= 1.0" ]
                 ],
-  SuggestedOtherPackages := [ ],
+  SuggestedOtherPackages := [
+                [ "IO", ">= 2.3" ],
+  ],
   ExternalConditions := []
                       
 ),

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "HomalgToCAS",
 Subtitle := "A window to the outer world",
-Version := "2022.10-01",
+Version := "2022.11-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/HomalgToCAS/gap/HomalgExternalMatrix.gi
+++ b/HomalgToCAS/gap/HomalgExternalMatrix.gi
@@ -397,7 +397,7 @@ InstallMethod( SaveHomalgMatrixToFile,
         [ IsString, IsHomalgInternalMatrixRep, IsHomalgInternalRingRep ],
         
   function( filename, M, R )
-    local mode, fs;
+    local mode;
     
     if not IsBound( M!.SaveAs ) then
         mode := "ListList";
@@ -407,18 +407,8 @@ InstallMethod( SaveHomalgMatrixToFile,
     
     if mode = "ListList" then
         
-        fs := IO_File( filename, "w" );
-        
-        if fs = fail then
-            Error( "unable to open the file ", filename, " for writing\n" );
-        fi;
-        
-        if IO_WriteFlush( fs, GetListListOfHomalgMatrixAsString( M ) ) = fail then
+        if FileString( filename, GetListListOfHomalgMatrixAsString( M ) ) = fail then
             Error( "unable to write in the file ", filename, "\n" );
-        fi;
-        
-        if IO_Close( fs ) = fail then
-            Error( "unable to close the file ", filename, "\n" );
         fi;
         
     fi;
@@ -433,7 +423,7 @@ InstallMethod( LoadHomalgMatrixFromFile,
         [ IsString, IsHomalgInternalRingRep ],
         
   function( filename, R )
-    local mode, fs, str, z, M;
+    local mode, str, z, M;
     
     if not IsBound( R!.LoadAs ) then
         mode := "ListList";
@@ -443,20 +433,10 @@ InstallMethod( LoadHomalgMatrixFromFile,
     
     if mode = "ListList" then
         
-        fs := IO_File( filename, "r" );
-        
-        if fs = fail then
-            Error( "unable to open the file ", filename, " for reading\n" );
-        fi;
-        
-        str := IO_ReadUntilEOF( fs );
+        str := StringFile( filename );
         
         if str = fail then
             Error( "unable to read lines from the file ", filename, "\n" );
-        fi;
-        
-        if IO_Close( fs ) = fail then
-            Error( "unable to close the file ", filename, "\n" );
         fi;
         
         if IsBound( R!.NameOfPrimitiveElement ) and

--- a/HomalgToCAS/gap/HomalgExternalMatrix.gi
+++ b/HomalgToCAS/gap/HomalgExternalMatrix.gi
@@ -375,18 +375,6 @@ InstallMethod( SaveHomalgMatrixToFile,
         return SaveHomalgMatrixToFile( filename, M );
     fi;
     
-    fs := IO_File( filename, "w" );
-    
-    if fs = fail then
-        Error( "unable to open the file ", filename, " for writing\n" );
-    fi;
-    
-    if IO_Close( fs ) = fail then
-        Error( "unable to close the file ", filename, "\n" );
-    fi;
-    
-    Exec( Concatenation( "/bin/rm -f \"", filename, "\"" ) );
-    
     return SaveHomalgMatrixToFile( filename, M, HomalgRing( M ) );
     
 end );

--- a/HomalgToCAS/gap/HomalgExternalMatrix.gi
+++ b/HomalgToCAS/gap/HomalgExternalMatrix.gi
@@ -370,12 +370,7 @@ InstallMethod( SaveHomalgMatrixToFile,
   function( filename, M )
     local fs;
     
-    fs := IO_File( filename, "r" );
-    
-    if fs <> fail then
-        if IO_Close( fs ) = fail then
-            Error( "unable to close the file ", filename, "\n" );
-        fi;
+    if IsExistingFile( filename ) then
         Error( "the file ", filename, " already exists, please delete it first and then type return; to continue\n" );
         return SaveHomalgMatrixToFile( filename, M );
     fi;

--- a/HomalgToCAS/gap/HomalgExternalMatrix.gi
+++ b/HomalgToCAS/gap/HomalgExternalMatrix.gi
@@ -268,28 +268,12 @@ InstallMethod( ConvertHomalgMatrixViaFile,
         
   function( M, RR )
     
-    local R, r, c, separator, directory, pointer, pid, file, filename, fs, remove, MM;
+    local R, r, c, separator, pointer, pid, file, filename, fs, remove, MM;
     
     R := HomalgRing( M ); # the source ring
     
     r := NrRows( M );
     c := NrColumns( M );
-    
-    ## figure out the directory separtor:
-    if IsBound( GAPInfo.UserHome ) then
-        separator := GAPInfo.UserHome[1];
-    else
-        separator := '/';
-    fi;
-    
-    if IsBound( HOMALG_IO.DirectoryForTemporaryFiles ) then
-        directory := HOMALG_IO.DirectoryForTemporaryFiles;
-        if directory[Length(directory)] <> separator then
-            directory[Length(directory) + 1] := separator;
-        fi;
-    else
-        directory := "";
-    fi;
     
     if IsHomalgExternalMatrixRep( M ) then
         pointer := homalgPointer( M );
@@ -312,31 +296,7 @@ InstallMethod( ConvertHomalgMatrixViaFile,
     
     file := Concatenation( pointer, pid );
     
-    filename := Concatenation( directory, file );
-    
-    fs := IO_File( filename, "w" );
-    
-    if fs = fail then
-        if not ( IsBound( HOMALG_IO.DoNotFigureOutAnAlternativeDirectoryForTemporaryFiles ) 
-                 and HOMALG_IO.DoNotFigureOutAnAlternativeDirectoryForTemporaryFiles = true ) then
-            directory := FigureOutAnAlternativeDirectoryForTemporaryFiles( file );
-            if directory <> fail then
-                filename := Concatenation( directory, file );
-                fs := IO_File( filename, "w" );
-            else
-                Error( "unable to (find alternative directories to) open the file ", filename, " for writing\n" );
-            fi;
-        else
-            Error( "unable to open the file ", filename, " for writing\n" );
-        fi;
-        HOMALG_IO.DirectoryForTemporaryFiles := directory;
-    fi;
-    
-    if IO_Close( fs ) = fail then
-        Error( "unable to close the file ", filename, "\n" );
-    fi;
-    
-    Exec( Concatenation( "/bin/rm -f \"", filename, "\"" ) );
+    filename := Filename( HOMALG_IO.DirectoryForTemporaryFiles, file );
     
     remove := SaveHomalgMatrixToFile( filename, M );
     

--- a/HomalgToCAS/gap/HomalgExternalMatrix.gi
+++ b/HomalgToCAS/gap/HomalgExternalMatrix.gi
@@ -303,7 +303,7 @@ InstallMethod( ConvertHomalgMatrixViaFile,
         fi;
         
         if not IsBound( HOMALG_IO.PID ) or not IsInt( HOMALG_IO.PID ) then
-            HOMALG_IO.PID := 99999; #this is not the real PID!
+            HOMALG_IO.PID := -1; #this is not the real PID!
         fi;
         
         pid := Concatenation( "_PID_", String( HOMALG_IO.PID ) );

--- a/HomalgToCAS/gap/HomalgToCAS.gd
+++ b/HomalgToCAS/gap/HomalgToCAS.gd
@@ -19,8 +19,6 @@ DeclareGlobalVariable( "HOMALG_IO" );
 #
 ####################################
 
-DeclareGlobalFunction( "FigureOutAnAlternativeDirectoryForTemporaryFiles" );
-
 DeclareGlobalFunction( "homalgTime" );
 
 DeclareGlobalFunction( "homalgMemoryUsage" );

--- a/HomalgToCAS/gap/HomalgToCAS.gi
+++ b/HomalgToCAS/gap/HomalgToCAS.gi
@@ -27,7 +27,7 @@ InstallValue( HOMALG_IO,
             ListOfAlternativeDirectoryForTemporaryFiles := [ "/tmp/", "/dev/shm/", "/var/tmp/", "./" ],
             FileNameCounter := 1,
             DeletePeriod := 500,
-            PID := IO_getpid(),
+            PID := (function() if IsBoundGlobal( "IO_getpid" ) then return ValueGlobal( "IO_getpid" )(); else return -1; fi; end)(),
             save_CAS_commands_to_file := false,
             suppress_CAS := false,
             suppress_PID := false,
@@ -837,10 +837,20 @@ InstallGlobalFunction( FingerprintOfGapProcess,
               BuildDateTime := GAPInfo.BuildDateTime,
               Architecture := GAPInfo.Architecture,
               SystemCommandLine := GAPInfo.SystemCommandLine,
-              Hostname :=IO_gethostname(),
-              PID := IO_getpid(),
               TimeOfDay := GetTimeOfDay()
               );
+    
+    if IsBoundGlobal( "IO_gethostname" ) then
+        f.Hostname := ValueGlobal( "IO_gethostname" )();
+    else
+        f.Hostname := "unknown";
+    fi;
+    
+    if IsBoundGlobal( "IO_getpid" ) then
+        f.PID := ValueGlobal( "IO_getpid" )();
+    else
+        f.PID := -1;
+    fi;
     
     if Length( arg ) > 0 then
         if Length( arg ) = 1 then

--- a/HomalgToCAS/gap/HomalgToCAS.gi
+++ b/HomalgToCAS/gap/HomalgToCAS.gi
@@ -21,10 +21,8 @@ InstallValue( HOMALG_IO,
             InformAboutCASystemsWithoutActiveRings := true,
             SaveHomalgMaximumBackStream := false,
             color_display := false,
-            DirectoryForTemporaryFiles := "/tmp/",
-            DoNotFigureOutAnAlternativeDirectoryForTemporaryFiles := false,
+            DirectoryForTemporaryFiles := DirectoryTemporary(),
             DoNotDeleteTemporaryFiles := false,
-            ListOfAlternativeDirectoryForTemporaryFiles := [ "/tmp/", "/dev/shm/", "/var/tmp/", "./" ],
             FileNameCounter := 1,
             DeletePeriod := 500,
             PID := (function() if IsBoundGlobal( "IO_getpid" ) then return ValueGlobal( "IO_getpid" )(); else return -1; fi; end)(),
@@ -519,6 +517,10 @@ InstallValue( HOMALG_IO,
            )
 );
 
+if HOMALG_IO.DirectoryForTemporaryFiles = fail then
+    Display( "WARNING: GAP could not create a temporary directory. You may encounter errors." );
+fi;
+
 ####################################
 #
 # global functions and operations:
@@ -611,65 +613,6 @@ InstallGlobalFunction( homalgMemoryUsage,
     fi;
     
     return stream.memory_usage( stream, o );
-    
-end );
-
-##
-InstallGlobalFunction( FigureOutAnAlternativeDirectoryForTemporaryFiles,
-  function( arg )
-    local nargs, file, list, separator, pos_sep, l, directory, filename, fs;
-    
-    nargs := Length( arg );
-    
-    if nargs = 0 then
-        Error( "empty input" );
-    fi;
-    
-    file := arg[1];
-    
-    if IsBound( HOMALG_IO.ListOfAlternativeDirectoryForTemporaryFiles ) then
-        list := HOMALG_IO.ListOfAlternativeDirectoryForTemporaryFiles;
-    else
-        list := [ "/tmp/", "/dev/shm/", "/var/tmp/" ];
-    fi;
-    
-    ## figure out the directory separtor:
-    if IsBound( GAPInfo.UserHome ) then
-        separator := GAPInfo.UserHome[1];
-    else
-        separator := '/';
-    fi;
-    
-    if nargs > 1 then
-        pos_sep := PositionProperty( Reversed( file ), c -> c = separator );
-        if pos_sep <> fail then
-            l := Length( file );
-            file := file{[ l - pos_sep + 2 .. l ]};
-        fi;
-    fi;
-    
-    for directory in list do
-        
-        if directory[Length( directory )] <> separator then
-            filename := Concatenation( directory, [ separator ], file );
-        else
-            filename := Concatenation( directory, file );
-        fi;
-        
-        fs := IO_File( filename, "w" );
-        
-        if fs <> fail then
-            IO_Close( fs );
-            if nargs > 1 and arg[2] = "with_filename" then
-                return filename;
-            else
-                return directory;
-            fi;
-        fi;
-        
-    od;
-    
-    return fail;
     
 end );
 

--- a/HomalgToCAS/gap/homalgSendBlocking.gi
+++ b/HomalgToCAS/gap/homalgSendBlocking.gi
@@ -715,14 +715,8 @@ InstallGlobalFunction( homalgSendBlocking,
             fi;
         fi;
         
-        fs := IO_File( stream.CAS_commands_file, "a" );
-        
-        if IO_WriteFlush( fs, L ) = fail then
+        if FileString( stream.CAS_commands_file, L, true ) = fail then
             Error( "unable to write in the file ", stream.CAS_commands_file, "\n" );
-        fi;
-        
-        if IO_Close( fs ) = fail then
-            Error( "unable to close the file ", stream.CAS_commands_file, "\n" );
         fi;
     fi;
     

--- a/HomalgToCAS/gap/homalgSendBlocking.gi
+++ b/HomalgToCAS/gap/homalgSendBlocking.gi
@@ -434,7 +434,7 @@ InstallGlobalFunction( homalgSendBlocking,
           pictogram, option, break_lists, R, ext_obj, stream, type, prefix,
           suffix, e, RP, CAS, PID, container, counter, homalg_variable,
           used_pointers, void_matrices, l, eoc, enter, statistics, statistics_summary,
-          fs, io_info_level, picto, void_matrix, o, max, display_color, esc;
+          io_info_level, picto, void_matrix, o, max, display_color, esc;
     
     if IsBound( HOMALG_IO.homalgSendBlockingInput ) then
         Add( HOMALG_IO.homalgSendBlockingInput, arg );
@@ -706,12 +706,9 @@ InstallGlobalFunction( homalgSendBlocking,
        or IsBound( stream.CAS_commands_file ) then
         if not IsBound( stream.CAS_commands_file ) then
             stream.CAS_commands_file := Concatenation( "commands_file_of_", CAS, "_with_PID_", String( PID ) );
-            fs := IO_File( stream.CAS_commands_file, "w" );
-            if fs = fail then
-                Error( "unable to open the file ", stream.CAS_commands_file, " for writing\n" );
-            fi;
-            if IO_Close( fs ) = fail then
-                Error( "unable to close the file ", stream.CAS_commands_file, "\n" );
+            if IsExistingFile( stream.CAS_commands_file ) then
+                Error( "the file ", stream.CAS_commands_file, " already exists, type return; to overwrite it\n" );
+                FileString( stream.CAS_commands_file, "" );
             fi;
         fi;
         

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "MatricesForHomalg",
 Subtitle := "Matrices for the homalg project",
-Version := "2022.10-06",
+Version := "2022.11-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -114,7 +114,7 @@ Dependencies := rec(
   NeededOtherPackages := [
                    [ "ToolsForHomalg", ">= 2018.12.15" ],
                    [ "GAPDoc", ">= 1.0" ] ],
-  SuggestedOtherPackages := [ [ "utils", ">= 0.54" ] ],
+  SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       
 ),

--- a/RingsForHomalg/PackageInfo.g
+++ b/RingsForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "RingsForHomalg",
 Subtitle := "Dictionaries of external rings",
-Version := "2022.10-02",
+Version := "2022.11-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/RingsForHomalg/gap/Singular.gi
+++ b/RingsForHomalg/gap/Singular.gi
@@ -2901,8 +2901,8 @@ InstallMethod( LoadHomalgMatrixFromFile,
         "for homalg external rings in Singular",
         [ IsString, IsInt, IsInt, IsHomalgExternalRingInSingularRep ],
         
-  function( filename, r, c, R )
-    local mode, fs, str, fname, v, command, M;
+  function( filepath, r, c, R )
+    local mode, str, separator, pos_sep, l, filename, fname, M, v, command;
     
     if not IsBound( R!.LoadAs ) then
         mode := "ListList";
@@ -2911,16 +2911,29 @@ InstallMethod( LoadHomalgMatrixFromFile,
     fi;
     
     #read the file with GAP and parse it for better Singular reading:
-    str := StringFile( filename );
+    str := StringFile( filepath );
     if str = fail then
-        Error( "unable to read lines from the file ", filename, "\n" );
+        Error( "unable to read lines from the file ", filepath, "\n" );
     fi;
     
     str := Filtered( str, c -> not c in " []" );
     
-    fname := Concatenation( filename, "-singular" );
+    # get basename of filepath
+    if IsBound( GAPInfo.UserHome ) then
+        separator := GAPInfo.UserHome[1];
+    else
+        separator := '/';
+    fi;
     
-    fname := FigureOutAnAlternativeDirectoryForTemporaryFiles( fname, "with_filename" );
+    pos_sep := PositionProperty( Reversed( filepath ), c -> c = separator );
+    if pos_sep = fail then
+        filename := filepath;
+    else
+        l := Length( filepath );
+        filename := filepath{[ l - pos_sep + 2 .. l ]};
+    fi;
+    
+    fname := Filename( HOMALG_IO.DirectoryForTemporaryFiles, Concatenation( filename, "-singular" ) );
     
     if FileString( fname, str ) = fail then
         Error( "unable to write in the file ", fname, "\n" );

--- a/RingsForHomalg/gap/Singular.gi
+++ b/RingsForHomalg/gap/Singular.gi
@@ -2911,16 +2911,9 @@ InstallMethod( LoadHomalgMatrixFromFile,
     fi;
     
     #read the file with GAP and parse it for better Singular reading:
-    fs := IO_File( filename, "r" );
-    if fs = fail then
-        Error( "unable to open the file ", filename, " for reading\n" );
-    fi;
-    str := IO_ReadUntilEOF( fs );
+    str := StringFile( filename );
     if str = fail then
         Error( "unable to read lines from the file ", filename, "\n" );
-    fi;
-    if IO_Close( fs ) = fail then
-        Error( "unable to close the file ", filename, "\n" );
     fi;
     
     str := Filtered( str, c -> not c in " []" );
@@ -2929,15 +2922,8 @@ InstallMethod( LoadHomalgMatrixFromFile,
     
     fname := FigureOutAnAlternativeDirectoryForTemporaryFiles( fname, "with_filename" );
     
-    fs := IO_File( fname, "w" );
-    if fs = fail then
-        Error( "unable to open the file ", fname, " for writing\n" );
-    fi;
-    if IO_WriteFlush( fs, str ) = fail then
+    if FileString( fname, str ) = fail then
         Error( "unable to write in the file ", fname, "\n" );
-    fi;
-    if IO_Close( fs ) = fail then
-        Error( "unable to close the file ", fname, "\n" );
     fi;
     
     M := HomalgVoidMatrix( R );


### PR DESCRIPTION
See commit messages for details.

4ti2Interface and IO_ForHomalg still depend on IO and use it for more intricate stuff than reading and writing files. Maybe one could also use native GAP functions there or at least make the parts really needing IO optional, but I don't plan to look into this.

Does CapAndHomalg.jl need IO_ForHomalg when talking to Singular.jl? If not, this PR allows to use Singular in CapAndHomalg.jl without IO.