### PR TITLE
Turn UnderlyingObject into an attribute

### DIFF
--- a/homalg/PackageInfo.g
+++ b/homalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "homalg",
 Subtitle := "A homological algebra meta-package for computable Abelian categories",
-Version := "2022.11-01",
+Version := "2022.12-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/homalg/gap/HomalgFiltration.gd
+++ b/homalg/gap/HomalgFiltration.gd
@@ -135,8 +135,7 @@ DeclareOperation( "LowestDegreeMorphism",
 DeclareOperation( "HighestDegreeMorphism",
         [ IsHomalgFiltration ] );
 
-DeclareOperation( "UnderlyingObject",
-        [ IsHomalgFiltration ] );
+DeclareAttribute( "UnderlyingObject", IsHomalgFiltration );
 
 DeclareOperation( "IsomorphismOfFiltration",
         [ IsHomalgFiltration ] );

--- a/homalg/gap/HomalgSubobject.gd
+++ b/homalg/gap/HomalgSubobject.gd
@@ -95,8 +95,7 @@ DeclareAttribute( "EpiOnFactorObject",
 DeclareOperation( "MorphismHavingSubobjectAsItsImage",
         [ IsHomalgObject ] );
 
-DeclareOperation( "UnderlyingObject",
-        [ IsHomalgObject ] );
+DeclareAttribute( "UnderlyingObject", IsHomalgObject );
 
 DeclareOperation( "IsSubset",
         [ IsStructureObjectOrObjectOrMorphism, IsStructureObjectOrObjectOrMorphism ] );


### PR DESCRIPTION
I want to use `UnderlyingObject` as an attribute in `CategoryOfCospans`. Due to the lack of documentation I am not 100% sure that using it as an attribute of `IsHomalgFiltration` and `IsHomalgObject` is correct (i.e. that the underlying object of a given filtration or object does not change in the course of the computation), so please double-check.