### PR TITLE
Turn UnderlyingObject into an attribute

### DIFF
--- a/homalg/PackageInfo.g
+++ b/homalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "homalg",
 Subtitle := "A homological algebra meta-package for computable Abelian categories",
-Version := "2022.12-02",
+Version := "2023.02-01",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/homalg/gap/HomalgFiltration.gd
+++ b/homalg/gap/HomalgFiltration.gd
@@ -135,8 +135,11 @@ DeclareOperation( "LowestDegreeMorphism",
 DeclareOperation( "HighestDegreeMorphism",
         [ IsHomalgFiltration ] );
 
-DeclareOperation( "UnderlyingObject",
-        [ IsHomalgFiltration ] );
+if IsBoundGlobal( "UnderlyingObject" ) and not IsAttribute( ValueGlobal( "UnderlyingObject" ) ) then
+    DeclareOperation( "UnderlyingObject", [ IsHomalgFiltration ] );
+else
+    DeclareAttribute( "UnderlyingObject", IsHomalgFiltration );
+fi;
 
 DeclareOperation( "IsomorphismOfFiltration",
         [ IsHomalgFiltration ] );

--- a/homalg/gap/HomalgSubobject.gd
+++ b/homalg/gap/HomalgSubobject.gd
@@ -95,8 +95,11 @@ DeclareAttribute( "EpiOnFactorObject",
 DeclareOperation( "MorphismHavingSubobjectAsItsImage",
         [ IsHomalgObject ] );
 
-DeclareOperation( "UnderlyingObject",
-        [ IsHomalgObject ] );
+if IsBoundGlobal( "UnderlyingObject" ) and not IsAttribute( ValueGlobal( "UnderlyingObject" ) ) then
+    DeclareOperation( "UnderlyingObject", [ IsHomalgObject ] );
+else
+    DeclareAttribute( "UnderlyingObject", IsHomalgObject );
+fi;
 
 DeclareOperation( "IsSubset",
         [ IsStructureObjectOrObjectOrMorphism, IsStructureObjectOrObjectOrMorphism ] );


### PR DESCRIPTION
except if it has already been created as an operation by other packages

This has previously caused issues with FinInG but with https://github.com/gap-packages/FinInG/pull/33 things should be fine now.