### PR TITLE
Initial(Index,Value) -> Starting(Index,Value) to avoid clashes with "InitialValue" in QPA

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
-Version := "2023.02-02",
+Version := "2023.02-03",
 Date := Concatenation( "01/", ~.Version{[ 6, 7 ]}, "/", ~.Version{[ 1 .. 4 ]} ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/gap/ZFunctions.gd
+++ b/ToolsForHomalg/gap/ZFunctions.gd
@@ -84,10 +84,10 @@ DeclareAttribute( "UpperFunction", IsZFunctionWithInductiveSides );
 DeclareAttribute( "LowerFunction", IsZFunctionWithInductiveSides );
 #! @Arguments z_func
 #! @Returns an integer
-DeclareAttribute( "InitialIndex", IsZFunctionWithInductiveSides );
+DeclareAttribute( "StartingIndex", IsZFunctionWithInductiveSides );
 #! @Arguments z_func
 #! @Returns a Gap object
-DeclareAttribute( "InitialValue", IsZFunctionWithInductiveSides );
+DeclareAttribute( "StartingValue", IsZFunctionWithInductiveSides );
 #! @EndGroup
 #! @Group 9228
 #! @Arguments z_func

--- a/ToolsForHomalg/gap/ZFunctions.gi
+++ b/ToolsForHomalg/gap/ZFunctions.gi
@@ -123,8 +123,8 @@ InstallMethod( ZFunctionWithInductiveSides,
     
     ObjectifyWithAttributes( z_function, TheTypeOfZFunctionsWithInductiveSides,
             UnderlyingFunction, func,
-            InitialIndex, N,
-            InitialValue, value_N,
+            StartingIndex, N,
+            StartingValue, value_N,
             UpperFunction, upper_func,
             LowerFunction, lower_func,
             CompareFunction, compare_func );


### PR DESCRIPTION
& bump version to v2023.02-03

(reported at https://github.com/gap-system/PackageDistro/pull/720#issuecomment-1437411538)