### PR TITLE
Clone other repos earlier

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -49,6 +49,15 @@ jobs:
         run: |
           cp ./homalg_project/dev/ci_gaprc /home/gap/.gap/gaprc
           git clone --depth 1 -vv https://github.com/gap-packages/AutoDoc.git
+          git clone --depth 1 -vv https://github.com/homalg-project/alcove.git
+          git clone --depth 1 -vv https://github.com/homalg-project/alexander.git
+          git clone --depth 1 -vv https://github.com/homalg-project/CddInterface.git
+          git clone --depth 1 -vv https://github.com/homalg-project/CAP_project.git
+          git clone --depth 1 -vv https://github.com/homalg-project/D-Modules.git
+          git clone --depth 1 -vv https://github.com/homalg-project/NConvex.git
+          git clone --depth 1 -vv https://github.com/homalg-project/Sheaves.git
+          git clone --depth 1 -vv https://github.com/homalg-project/ToricVarieties_project.git
+          git clone --depth 1 -vv https://github.com/homalg-project/VirtualCAS.git
       - name: Build documentation of packages which we might want to reference
         run: |
           # keep this in sync with `dev/.release`

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,28 @@ pipeline {
 	stages {
 		stage('test') {
 			steps {
+				dir('pkg') {
+					sh 'rm -rf alcove; git clone --depth 1 https://github.com/homalg-project/alcove.git'
+					sh 'rm -rf alexander; git clone --depth 1 https://github.com/homalg-project/alexander.git'
+					sh 'rm -rf CddInterface; git clone --depth 1 https://github.com/homalg-project/CddInterface.git'
+					sh 'rm -rf CAP_project; git clone --depth 1 https://github.com/homalg-project/CAP_project.git'
+					sh 'rm -rf D-Modules; git clone --depth 1 https://github.com/homalg-project/D-Modules.git'
+					sh 'rm -rf NConvex; git clone --depth 1 https://github.com/homalg-project/NConvex.git'
+					sh 'rm -rf Sheaves; git clone --depth 1 https://github.com/homalg-project/Sheaves.git'
+					sh 'rm -rf ToricVarieties_project; git clone --depth 1 https://github.com/homalg-project/ToricVarieties_project.git'
+					sh 'rm -rf VirtualCAS; git clone --depth 1 https://github.com/homalg-project/VirtualCAS.git'
+				}
+
+				dir('pkg') {
+					sh 'make -C "CAP_project/CAP" doc'
+					sh 'make -C "CAP_project/CompilerForCAP" doc'
+					sh 'make -C "CAP_project/MonoidalCategories" doc'
+					sh 'make -C "CAP_project/CartesianCategories" doc'
+					sh 'make -C "CAP_project/FreydCategoriesForCAP" doc'
+					sh 'make -C "homalg_project/homalg" doc'
+					sh 'make -C "homalg_project/Modules" doc'
+				}
+
 				dir('pkg/homalg_project') {
 					sh 'make --trace -j $(nproc) --output-sync ci-test'
 				}

--- a/ci_prepare
+++ b/ci_prepare
@@ -2,24 +2,6 @@
 
 cd ..
 
-PACKAGES_TO_CLONE="
-alcove
-alexander
-CddInterface
-CAP_project
-D-Modules
-NConvex
-Sheaves
-ToricVarieties_project
-VirtualCAS
-"
-
-for PACKAGE in $PACKAGES_TO_CLONE; do
-	if [ ! -e $PACKAGE ]; then
-		git clone "https://github.com/homalg-project/$PACKAGE.git"
-	fi
-done
-
 cd CddInterface
 ./install.sh $GAP_HOME
 cd ..


### PR DESCRIPTION
This allows to build the documentation of some packages before running the tests which prevents a race condition.