### PR TITLE
install method for \{\}(lazy_list, list) and bump version

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
-Version := "2023.03-01",
+Version := "2023.05-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/gap/LazyHLists.gi
+++ b/ToolsForHomalg/gap/LazyHLists.gi
@@ -171,7 +171,7 @@ InstallMethod( \{\},
         
   function( L, l )
     
-    Error( "not implemented yet\n" );
+    return LazyHList( l, i -> L[i] );
     
 end );
 


### PR DESCRIPTION
of ToolsForHomalg to V2023.05.01