### PR TITLE
Introduce CallFuncListWithUserTime

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
-Version := "2023.07-01",
+Version := "2023.10-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/gap/ToolsForHomalg.gd
+++ b/ToolsForHomalg/gap/ToolsForHomalg.gd
@@ -454,6 +454,7 @@ DeclareOperation( "ShaSum",
 DeclareGlobalFunction( "GetTimeOfDay" );
 
 DeclareGlobalFunction( "CallFuncListWithTime" );
+DeclareGlobalFunction( "CallFuncListWithUserTime" );
 
 #! @Description
 #!  returns  a new list that contains for each element <A>elm</A> of the list <A>list</A> a list of length two,

--- a/ToolsForHomalg/gap/ToolsForHomalg.gi
+++ b/ToolsForHomalg/gap/ToolsForHomalg.gi
@@ -1704,6 +1704,29 @@ InstallGlobalFunction( CallFuncListWithTime,
 end );
 
 ##
+InstallGlobalFunction( CallFuncListWithUserTime,
+  function( func, arguments )
+    local output, t0, t1;
+    
+    if not IsList( arguments ) then
+        
+        return CallFuncListWithUserTime( func, [ arguments ] );
+        
+    fi;
+    
+    t0 := Runtime( );
+    
+    output := CallFuncList( func, arguments );
+    
+    t1 := Runtime( );
+    
+    Print( t1 - t0, " ms\n" );
+    
+    return output;
+    
+end );
+
+##
 InstallGlobalFunction( CollectEntries,
   function( list )
     local comparing_func, o, n;


### PR DESCRIPTION
a version of CallFuncListWithTime which uses `Runtime` instead of `NanosecondsSinceEpoch`