### PR TITLE
Introduce RingFilter and RingElementFilter

### DIFF
--- a/GaussForHomalg/PackageInfo.g
+++ b/GaussForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "GaussForHomalg",
 Subtitle := "Gauss functionality for the homalg project",
-Version := "2023.10-01",
+Version := "2023.11-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -80,6 +80,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.12.1",
   NeededOtherPackages := [
+                [ "ToolsForHomalg", ">= 2023.11-01" ],
                 [ "Gauss", ">= 2021.04-01" ],
                 [ "MatricesForHomalg", ">= 2023.10-01" ],
                 [ "GAPDoc", ">= 1.0" ] ],

--- a/GaussForHomalg/gap/GaussRationals.gi
+++ b/GaussForHomalg/gap/GaussRationals.gi
@@ -114,6 +114,9 @@ InstallGlobalFunction( HomalgFieldOfRationals,
     
     R := CreateHomalgRing( Rationals );
     
+    SetRingFilter( R, IsHomalgRing );
+    SetRingElementFilter( R, IsRat );
+    
     SetIsRationalsForHomalg( R, true );
     
     SetRingProperties( R, 0 );

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "HomalgToCAS",
 Subtitle := "A window to the outer world",
-Version := "2023.08-01",
+Version := "2023.11-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -160,6 +160,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.12.1",
   NeededOtherPackages := [
+                [ "ToolsForHomalg", ">= 2023.11-01" ],
                 [ "MatricesForHomalg", ">= 2023.08-01" ],
                 [ "GAPDoc", ">= 1.0" ]
                 ],

--- a/HomalgToCAS/gap/HomalgExternalRing.gi
+++ b/HomalgToCAS/gap/HomalgExternalRing.gi
@@ -501,6 +501,9 @@ InstallGlobalFunction( CreateHomalgExternalRing,
     ## create the external ring
     R :=  CallFuncList( CreateHomalgRing, ar );
     
+    SetRingFilter( R, IsHomalgRing );
+    SetRingElementFilter( R, IsHomalgRingElement );
+    
     ## for the view methods:
     ## <A matrix over an external ring>
     R!.description := "n external";

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "MatricesForHomalg",
 Subtitle := "Matrices for the homalg project",
-Version := "2023.11-01",
+Version := "2023.11-02",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 
@@ -112,7 +112,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.12.1",
   NeededOtherPackages := [
-                   [ "ToolsForHomalg", ">= 2018.12.15" ],
+                   [ "ToolsForHomalg", ">= 2023.11-01" ],
                    [ "GAPDoc", ">= 1.0" ] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []

--- a/MatricesForHomalg/gap/HomalgRing.gi
+++ b/MatricesForHomalg/gap/HomalgRing.gi
@@ -2078,6 +2078,8 @@ InstallGlobalFunction( HomalgRingOfIntegers,
     if nargs = 0 or arg[1] = 0 then
         c := 0;
         R := CreateHomalgRing( Integers );
+        SetRingFilter( R, IsHomalgRing );
+        SetRingElementFilter( R, IsInt );
     elif IsInt( arg[1] ) then
         c := arg[1];
         if Length( Collected( FactorsInt( c ) ) ) = 1 and IsPackageMarkedForLoading( "GaussForHomalg", ">= 2018.09.20") then

--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
-Version := "2023.10-01",
+Version := "2023.11-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/gap/ToolsForHomalg.gd
+++ b/ToolsForHomalg/gap/ToolsForHomalg.gd
@@ -78,6 +78,35 @@ DeclareCategory( "IsContainerForPointers",
 
 ####################################
 #
+# attributes:
+#
+####################################
+
+#! @Section Attributes
+
+#! @Description
+#! A filter inheriting from `IsRing` which uniquely identifies the ring <A>ring</A>.
+#! For example, the ring `Integers` is identified by `IsIntegers`.
+#! If no filter uniquely identifying the ring exists,
+#! the most special filter available should be chosen.
+#! @Arguments ring
+DeclareAttribute( "RingFilter",
+                  IsRing );
+
+#! @Description
+#! A filter inheriting from `IsRingElement` which uniquely identifies elements of the ring <A>ring</A>.
+#! For example, the elements of the ring `Integers` are identified by `IsInt`.
+#! If no filter uniquely identifying the elements of the ring exists,
+#! the most special filter available should be chosen.
+#! @Arguments ring
+DeclareAttribute( "RingElementFilter",
+                  IsRing );
+
+SetRingFilter( Integers, IsIntegers );
+SetRingElementFilter( Integers, IsInt );
+
+####################################
+#
 # global functions and operations:
 #
 ####################################


### PR DESCRIPTION
This more or less corresponds to `CategoryFilter` and `ObjectFilter` etc. in CAP and is needed to handle commutative rings of linear categories in a clean way in CAP. Note: I have not covered all homalg rings. If you want to cover more rings, maybe we can do this together. If a ring is not covered, CAP will simply fall back to `IsRing` and `IsRingElement`, so the type checking is less strict, but nothing breaks.