### PR TITLE
Add RingFilter and RingElementFilter to more rings

### DIFF
--- a/GaussForHomalg/PackageInfo.g
+++ b/GaussForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "GaussForHomalg",
 Subtitle := "Gauss functionality for the homalg project",
-Version := "2023.11-01",
+Version := "2024.07-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/GaussForHomalg/gap/GaussTools.gi
+++ b/GaussForHomalg/gap/GaussTools.gi
@@ -406,11 +406,18 @@ InstallGlobalFunction( HOMALG_RING_OF_INTEGERS_PRIME_POWER_HELPER,
             d := 1;
         fi;
         R := CreateHomalgRing( GF( c, d ) );
+        
+        SetRingFilter( R, IsHomalgRing );
+        SetRingElementFilter( R, IsFFE );
+        
         R!.NameOfPrimitiveElement := Concatenation( "Z", String( c ), "_", String( d ) );
         SetIsFieldForHomalg( R, true );
         SetRingProperties( R, c, d );
     else
         R := CreateHomalgRing( ZmodnZ( c ) );
+        
+        SetRingFilter( R, IsHomalgRing );
+        SetRingElementFilter( R, IsZmodnZObj );
     fi;
     return R;
 end );

--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "GradedRingForHomalg",
 Subtitle := "Endow Commutative Rings with an Abelian Grading",
-Version := "2023.08-01",
+Version := "2024.07-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/GradedRingForHomalg/gap/GradedRing.gi
+++ b/GradedRingForHomalg/gap/GradedRing.gi
@@ -779,6 +779,10 @@ InstallMethod( GradedRing,
     
     ## create the graded ring
     S := CreateHomalgRing( R, [ TheTypeHomalgGradedRing, ValueGlobal( "TheTypeHomalgMatrixOverGradedRing" ) ], GradedRingElement, RP );
+    
+    SetRingFilter( S, IsHomalgGradedRingRep );
+    SetRingElementFilter( S, IsHomalgGradedRingElementRep );
+    
     SetConstructorForHomalgMatrices( S,
       function( arg )
         local nargs, mat, R, l;

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 
 PackageName := "MatricesForHomalg",
 Subtitle := "Matrices for the homalg project",
-Version := "2024.06-01",
+Version := "2024.07-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/MatricesForHomalg/gap/ResidueClassRing.gi
+++ b/MatricesForHomalg/gap/ResidueClassRing.gi
@@ -578,6 +578,9 @@ InstallMethod( \/, ## this operation is declared in the file HomalgRelations.gd
     ## create the residue class ring
     S := CreateHomalgRing( R, [ TheTypeHomalgResidueClassRing, TheTypeHomalgResidueClassMatrix ], HomalgResidueClassRingElement, RP );
     
+    SetRingFilter( S, IsHomalgResidueClassRingRep );
+    SetRingElementFilter( S, IsHomalgResidueClassRingElementRep );
+    
     ## the constructor of matrices over residue class rings
     SetConstructorForHomalgMatrices( S,
             function( arg )

--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
-Version := "2023.11-01",
+Version := "2024.07-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/gap/ToolsForHomalg.gd
+++ b/ToolsForHomalg/gap/ToolsForHomalg.gd
@@ -105,6 +105,9 @@ DeclareAttribute( "RingElementFilter",
 SetRingFilter( Integers, IsIntegers );
 SetRingElementFilter( Integers, IsInt );
 
+SetRingFilter( Rationals, IsRationals );
+SetRingElementFilter( Rationals, IsRat );
+
 ####################################
 #
 # global functions and operations:


### PR DESCRIPTION
https://github.com/homalg-project/CAP_project/pull/1628 requires all rings used for compilation and as `CommutativeRingOfLinearCategory` to have the attributes `RingFilter` and `RingElementFilter`. In particular, we have to set suitable filters for all homalg rings which we want to use as `CommutativeRingOfLinearCategory`. @mohamed-barakat Are you okay with this? This PR sets the required filters for all homalg rings appearing in the tests of `CAP_project`.