### PR TITLE
gauss: make use of IsKernelExtensionAvailable

### DIFF
--- a/Gauss/PackageInfo.g
+++ b/Gauss/PackageInfo.g
@@ -100,8 +100,7 @@ Dependencies := rec(
 ),
 
 AvailabilityTest := function()
-  if (not("gauss" in SHOW_STAT())) and
-     (Filename(DirectoriesPackagePrograms("gauss"), "gauss.so") = fail) then
+  if not IsKernelExtensionAvailable("gauss") then
     LogPackageLoadingMessage( PACKAGE_INFO, "Gauss C-module was not compiled!", "Gauss" );
     LogPackageLoadingMessage( PACKAGE_INFO, "Gauss will work, but slower.", "Gauss" );
   fi;


### PR DESCRIPTION
This was introduced alongside LoadKernelExtension which gauss
already uses.
