### PR TITLE
BindGlobal( "StringDisplayObj", ... )

### DIFF
--- a/ToolsForHomalg/PackageInfo.g
+++ b/ToolsForHomalg/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "ToolsForHomalg",
 Subtitle := "Special methods and knowledge propagation tools",
-Version := "2025.12-01",
+Version := "2026.02-01",
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",
 

--- a/ToolsForHomalg/gap/Julia.gi
+++ b/ToolsForHomalg/gap/Julia.gi
@@ -115,3 +115,15 @@ InstallMethod( Visualize,
     TryNextMethod( );
     
 end );
+
+## StringDisplayObj was removed from GAP.jl v0.16.4
+BindGlobal( "StringDisplayObj",
+  function(obj)
+    local str, out;
+    str := "";
+    out := OutputTextString(str, false);
+    SetPrintFormattingStatus(out, false);
+    CALL_WITH_STREAM(out, Display, [obj]);
+    CloseStream(out);
+    return str;
+end );


### PR DESCRIPTION
StringDisplayObj was removed from GAP.jl v0.16.4