### PR TITLE
Remove dependencies on GAPDoc

### DIFF
--- a/ExamplesForHomalg/PackageInfo.g
+++ b/ExamplesForHomalg/PackageInfo.g
@@ -102,7 +102,7 @@ Dependencies := rec(
                 [ "Modules", ">= 2023.10-01" ],
                 [ "homalg", ">= 2015.06.01" ],
                 [ "GaussForHomalg", ">=2023.08-01" ],
-                [ "GAPDoc", ">= 1.1" ] ],
+                ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       

--- a/Gauss/PackageInfo.g
+++ b/Gauss/PackageInfo.g
@@ -94,7 +94,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.13.0",
   NeededOtherPackages := [ ],
-  SuggestedOtherPackages := [ [ "GAPDoc", ">= 1.0" ] ],
+  SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       
 ),

--- a/GaussForHomalg/PackageInfo.g
+++ b/GaussForHomalg/PackageInfo.g
@@ -83,7 +83,7 @@ Dependencies := rec(
                 [ "ToolsForHomalg", ">= 2026.04-01" ],
                 [ "Gauss", ">= 2021.04-01" ],
                 [ "MatricesForHomalg", ">= 2026.04-01" ],
-                [ "GAPDoc", ">= 1.0" ] ],
+                ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       

--- a/GradedModules/PackageInfo.g
+++ b/GradedModules/PackageInfo.g
@@ -150,7 +150,7 @@ Dependencies := rec(
                    [ "GradedRingForHomalg", ">= 2023.08-01" ],
                    [ "homalg", ">= 2022.02-01" ],
                    [ "Modules", ">= 2026.04-01" ],
-                   [ "GAPDoc", ">= 1.0" ] ],
+                   ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       

--- a/GradedRingForHomalg/PackageInfo.g
+++ b/GradedRingForHomalg/PackageInfo.g
@@ -148,7 +148,7 @@ Dependencies := rec(
                    [ "RingsForHomalg", ">= 2023.08-01" ],
                    [ "homalg", ">=2011.08.16" ],
                    [ "Modules", ">= 2026.04-01" ],
-                   [ "GAPDoc", ">= 1.0" ] ],
+                   ],
   SuggestedOtherPackages := [
                    [  "NConvex", "2020.03.02" ],
                    [  "4ti2Interface", "2019.09.03" ] ],

--- a/HomalgToCAS/PackageInfo.g
+++ b/HomalgToCAS/PackageInfo.g
@@ -162,7 +162,6 @@ Dependencies := rec(
   NeededOtherPackages := [
                 [ "ToolsForHomalg", ">= 2026.04-01" ],
                 [ "MatricesForHomalg", ">= 2026.04-01" ],
-                [ "GAPDoc", ">= 1.0" ]
                 ],
   SuggestedOtherPackages := [
                 [ "IO", ">= 2.3" ],

--- a/IO_ForHomalg/PackageInfo.g
+++ b/IO_ForHomalg/PackageInfo.g
@@ -130,7 +130,7 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.13.0",
   NeededOtherPackages := [ [ "IO", ">= 2.3" ], [ "HomalgToCAS", ">= 2009.06.18" ] ],
-  SuggestedOtherPackages := [ [ "GAPDoc", ">= 1.0" ] ],
+  SuggestedOtherPackages := [],
   ExternalConditions := []
                       
 ),

--- a/MatricesForHomalg/PackageInfo.g
+++ b/MatricesForHomalg/PackageInfo.g
@@ -113,7 +113,7 @@ Dependencies := rec(
   GAP := ">= 4.13.0",
   NeededOtherPackages := [
                    [ "ToolsForHomalg", ">= 2026.04-01" ],
-                   [ "GAPDoc", ">= 1.0" ] ],
+                   ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       

--- a/Modules/PackageInfo.g
+++ b/Modules/PackageInfo.g
@@ -147,7 +147,7 @@ Dependencies := rec(
                    [ "MatricesForHomalg", ">= 2026.04-01" ],
                    [ "homalg", ">= 2022.02-01" ],
                    [ "GaussForHomalg", ">= 2026.04-01" ],
-                   [ "GAPDoc", ">= 1.0" ] ],
+                   ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       

--- a/SCO/PackageInfo.g
+++ b/SCO/PackageInfo.g
@@ -79,7 +79,6 @@ PackageDoc := rec(
 Dependencies := rec(
   GAP := ">= 4.13.0",
   NeededOtherPackages := [
-                   [ "GAPDoc", ">= 1.0" ],
                    [ "MatricesForHomalg", ">= 2023.08-01" ],
                    [ "Modules", ">= 2011.06.29" ],
                    ],

--- a/homalg/PackageInfo.g
+++ b/homalg/PackageInfo.g
@@ -96,7 +96,7 @@ Dependencies := rec(
   GAP := ">= 4.13.0",
   NeededOtherPackages := [
                    [ "ToolsForHomalg", ">=2012.10.27" ],
-                   [ "GAPDoc", ">= 1.0" ] ],
+                   ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := []
                       


### PR DESCRIPTION
As far as I can tell, these packages don't use code from
GAPDoc, so there is no reason to depend on it.
